### PR TITLE
Handle unknown tokens on fill page

### DIFF
--- a/src/features/fills/components/asset-amount.js
+++ b/src/features/fills/components/asset-amount.js
@@ -1,9 +1,10 @@
+import _ from 'lodash';
 import React from 'react';
 
 import formatToken from '../../../util/format-token';
 
 const AssetAmount = ({ asset }) =>
-  asset.amount !== undefined &&
+  _.isString(asset.amount) &&
   asset.type !== 'erc-721' && <>{formatToken(asset.amount)} </>;
 
 export default AssetAmount;

--- a/src/features/fills/components/asset-amount.test.js
+++ b/src/features/fills/components/asset-amount.test.js
@@ -36,4 +36,18 @@ describe('asset amount component', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('should render null for unknown ERC-20 asset', () => {
+    const { container } = render(
+      <AssetAmount
+        asset={{
+          amount: null,
+          tokenAddress: '0x12345',
+          type: 'erc-20',
+        }}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
 });


### PR DESCRIPTION
# Description

This PR fixes an issue which caused fills with an unknown asset (and therefore no asset amount) to throw an error.