### PR TITLE
Improve clarity around distinction between fill and trade volume

### DIFF
--- a/src/components/charts-container.js
+++ b/src/components/charts-container.js
@@ -131,8 +131,11 @@ class ChartsContainer extends PureComponent {
 ChartsContainer.propTypes = {
   charts: PropTypes.arrayOf(
     PropTypes.shape({
-      component: PropTypes.oneOfType([PropTypes.element, PropTypes.func])
-        .isRequired,
+      component: PropTypes.oneOfType([
+        PropTypes.element,
+        PropTypes.node,
+        PropTypes.object,
+      ]).isRequired,
       title: PropTypes.string.isRequired,
     }),
   ).isRequired,

--- a/src/features/dashboard/components/dashboard-metrics-carousel.js
+++ b/src/features/dashboard/components/dashboard-metrics-carousel.js
@@ -7,15 +7,20 @@ import '../../../styles/css/slick-carousel.css';
 
 import { breakpoints } from '../../../styles/constants';
 import FillCountMetric from './fill-count-metric';
-import NetworkFeesMetric from './network-fees-metric';
-import NetworkVolumeMetric from './network-volume-metric';
+import FillVolumeMetric from './fill-volume-metric';
+import TradeVolumeMetric from './trade-volume-metric';
 import ZRXPriceMetric from './zrx-price-metric';
 
 const CarouselMetric = styled.div`
   margin: 0 0.5rem;
 `;
 
-const DashboardMetricsCarousel = ({ className, fees, fillCount, volume }) => (
+const DashboardMetricsCarousel = ({
+  className,
+  fillCount,
+  fillVolume,
+  tradeVolume,
+}) => (
   <Slider
     arrows={false}
     centerMode
@@ -35,8 +40,8 @@ const DashboardMetricsCarousel = ({ className, fees, fillCount, volume }) => (
     slidesToScroll={3}
     slidesToShow={3}
   >
-    <CarouselMetric as={NetworkVolumeMetric} volume={volume} />
-    <CarouselMetric as={NetworkFeesMetric} fees={fees} />
+    <CarouselMetric as={FillVolumeMetric} volume={fillVolume} />
+    <CarouselMetric as={TradeVolumeMetric} volume={tradeVolume} />
     <CarouselMetric as={FillCountMetric} fillCount={fillCount} />
     <CarouselMetric as={ZRXPriceMetric} />
   </Slider>
@@ -44,16 +49,16 @@ const DashboardMetricsCarousel = ({ className, fees, fillCount, volume }) => (
 
 DashboardMetricsCarousel.propTypes = {
   className: PropTypes.string,
-  fees: PropTypes.number,
   fillCount: PropTypes.number,
-  volume: PropTypes.number,
+  fillVolume: PropTypes.number,
+  tradeVolume: PropTypes.number,
 };
 
 DashboardMetricsCarousel.defaultProps = {
   className: undefined,
-  fees: undefined,
   fillCount: undefined,
-  volume: undefined,
+  fillVolume: undefined,
+  tradeVolume: undefined,
 };
 
 export default DashboardMetricsCarousel;

--- a/src/features/dashboard/components/dashboard-metrics.js
+++ b/src/features/dashboard/components/dashboard-metrics.js
@@ -1,16 +1,14 @@
 import _ from 'lodash';
 import { connect } from 'react-redux';
-import { compose } from 'recompose';
 import { Col, Row } from 'reactstrap';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { TIME_PERIOD } from '../../../constants';
-import { getNetworkStats } from '../../stats/selectors';
-import AutoReload from '../../../util/auto-reload';
 import FillCountMetric from './fill-count-metric';
-import NetworkFeesMetric from './network-fees-metric';
-import NetworkVolumeMetric from './network-volume-metric';
+import FillVolumeMetric from './fill-volume-metric';
+import TradeVolumeMetric from './trade-volume-metric';
+import useNetworkStats from '../../stats/hooks/use-network-stats';
+import useRelayerStats from '../../stats/hooks/use-relayer-stats';
 import ZRXPriceMetric from './zrx-price-metric';
 
 // Carousel gets loaded lazily because it relies on react-slick
@@ -18,58 +16,51 @@ const AsyncDashboardMetricsCarousel = React.lazy(() =>
   import('./dashboard-metrics-carousel'),
 );
 
-class DashboardMetrics extends React.PureComponent {
-  componentDidMount() {
-    this.loadData();
-    AutoReload.addListener(this.loadData);
+const DashboardMetrics = ({ className, screenSize }) => {
+  const [networkStats, , networkStatsError] = useNetworkStats();
+  const [relayerStats, , relayerStatsError] = useRelayerStats();
+
+  if (networkStatsError) {
+    throw networkStatsError;
   }
 
-  componentWillUnmount() {
-    AutoReload.removeListener(this.loadData);
+  if (relayerStatsError) {
+    throw relayerStatsError;
   }
 
-  loadData = () => {
-    const { fetchNetworkStats } = this.props;
+  const fees = _.get(networkStats, 'fees.USD');
+  const fillCount = _.get(networkStats, 'fills');
+  const fillVolume = _.get(networkStats, 'volume');
+  const tradeVolume = _.get(relayerStats, 'tradeVolume');
 
-    fetchNetworkStats({ period: TIME_PERIOD.DAY });
-  };
-
-  render() {
-    const { className, networkStats, screenSize } = this.props;
-    const { volume } = _.pick(networkStats, 'volume');
-    const fees = _.get(networkStats, 'fees.USD');
-    const fillCount = _.get(networkStats, 'fills');
-
-    return screenSize.greaterThan.md ? (
-      <Row className={className}>
-        <Col lg={3} md={6}>
-          <NetworkVolumeMetric volume={volume} />
-        </Col>
-        <Col lg={3} md={6}>
-          <NetworkFeesMetric fees={fees} />
-        </Col>
-        <Col lg={3} md={6}>
-          <FillCountMetric fillCount={fillCount} />
-        </Col>
-        <Col lg={3} md={6}>
-          <ZRXPriceMetric />
-        </Col>
-      </Row>
-    ) : (
-      <AsyncDashboardMetricsCarousel
-        className={className}
-        fees={fees}
-        fillCount={fillCount}
-        volume={volume}
-      />
-    );
-  }
-}
+  return screenSize.greaterThan.md ? (
+    <Row className={className}>
+      <Col lg={3} md={6}>
+        <FillVolumeMetric volume={fillVolume} />
+      </Col>
+      <Col lg={3} md={6}>
+        <TradeVolumeMetric volume={tradeVolume} />
+      </Col>
+      <Col lg={3} md={6}>
+        <FillCountMetric fillCount={fillCount} />
+      </Col>
+      <Col lg={3} md={6}>
+        <ZRXPriceMetric />
+      </Col>
+    </Row>
+  ) : (
+    <AsyncDashboardMetricsCarousel
+      className={className}
+      fees={fees}
+      fillCount={fillCount}
+      fillVolume={fillVolume}
+      tradeVolume={tradeVolume}
+    />
+  );
+};
 
 DashboardMetrics.propTypes = {
   className: PropTypes.string,
-  fetchNetworkStats: PropTypes.func.isRequired,
-  networkStats: PropTypes.object,
   screenSize: PropTypes.shape({
     greaterThan: PropTypes.shape({
       md: PropTypes.bool.isRequired,
@@ -79,23 +70,10 @@ DashboardMetrics.propTypes = {
 
 DashboardMetrics.defaultProps = {
   className: undefined,
-  networkStats: undefined,
 };
 
 const mapStateToProps = state => ({
-  networkStats: getNetworkStats(state, { period: TIME_PERIOD.DAY }),
   screenSize: state.screen,
 });
 
-const mapDispatchToProps = dispatch => ({
-  fetchNetworkStats: dispatch.stats.fetchNetworkStats,
-});
-
-const enhance = compose(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  ),
-);
-
-export default enhance(DashboardMetrics);
+export default connect(mapStateToProps)(DashboardMetrics);

--- a/src/features/dashboard/components/dashboard-page.js
+++ b/src/features/dashboard/components/dashboard-page.js
@@ -50,9 +50,9 @@ const DashboardPage = ({ screenSize }) => (
       <DashboardColumn lg={7}>
         <ChartsContainer
           charts={[
-            { component: NetworkVolume, title: 'Network Volume' },
-            { component: <NetworkVolume type="fills" />, title: 'Fills' },
-            { component: NetworkFees, title: 'Fees' },
+            { component: NetworkVolume, title: 'Fill Volume' },
+            { component: <NetworkVolume type="fills" />, title: 'Fill Count' },
+            { component: NetworkFees, title: 'ZRX Fees' },
           ]}
           defaultPeriod={TIME_PERIOD.MONTH}
           periods={

--- a/src/features/dashboard/components/fill-count-metric.js
+++ b/src/features/dashboard/components/fill-count-metric.js
@@ -9,7 +9,7 @@ import LoadingIndicator from '../../../components/loading-indicator';
 const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
 
 const FillCountMetric = ({ className, fillCount }) => (
-  <DashboardMetric className={className} title="Fills (24H)">
+  <DashboardMetric className={className} title="Fill Count (24H)">
     {_.isNumber(fillCount)
       ? numeral(fillCount).format('0,0')
       : loadingIndicator}

--- a/src/features/dashboard/components/fill-volume-metric.js
+++ b/src/features/dashboard/components/fill-volume-metric.js
@@ -8,8 +8,8 @@ import LocalisedAmount from '../../currencies/components/localised-amount';
 
 const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
 
-const NetworkVolumeMetric = ({ className, volume }) => (
-  <DashboardMetric className={className} title="Network Volume (24H)">
+const FillVolumeMetric = ({ className, volume }) => (
+  <DashboardMetric className={className} title="Fill Volume (24H)">
     {_.isNumber(volume) ? (
       <LocalisedAmount amount={volume} loadingIndicator={loadingIndicator} />
     ) : (
@@ -18,14 +18,14 @@ const NetworkVolumeMetric = ({ className, volume }) => (
   </DashboardMetric>
 );
 
-NetworkVolumeMetric.propTypes = {
+FillVolumeMetric.propTypes = {
   className: PropTypes.string,
   volume: PropTypes.number,
 };
 
-NetworkVolumeMetric.defaultProps = {
+FillVolumeMetric.defaultProps = {
   className: undefined,
   volume: undefined,
 };
 
-export default NetworkVolumeMetric;
+export default FillVolumeMetric;

--- a/src/features/dashboard/components/trade-volume-metric.js
+++ b/src/features/dashboard/components/trade-volume-metric.js
@@ -8,24 +8,24 @@ import LocalisedAmount from '../../currencies/components/localised-amount';
 
 const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
 
-const NetworkFeesMetric = ({ className, fees }) => (
-  <DashboardMetric className={className} title="Network Fees (24H)">
-    {_.isNumber(fees) ? (
-      <LocalisedAmount amount={fees.USD} loadingIndicator={loadingIndicator} />
+const TradeVolumeMetric = ({ className, volume }) => (
+  <DashboardMetric className={className} title="Trade Volume (24H)">
+    {_.isNumber(volume) ? (
+      <LocalisedAmount amount={volume} loadingIndicator={loadingIndicator} />
     ) : (
       loadingIndicator
     )}
   </DashboardMetric>
 );
 
-NetworkFeesMetric.propTypes = {
-  className: PropTypes.number,
-  fees: PropTypes.number,
+TradeVolumeMetric.propTypes = {
+  className: PropTypes.string,
+  volume: PropTypes.number,
 };
 
-NetworkFeesMetric.defaultProps = {
+TradeVolumeMetric.defaultProps = {
   className: undefined,
-  fees: undefined,
+  volume: undefined,
 };
 
-export default NetworkFeesMetric;
+export default TradeVolumeMetric;

--- a/src/features/stats/hooks/use-network-stats.js
+++ b/src/features/stats/hooks/use-network-stats.js
@@ -1,0 +1,18 @@
+import useApi from '../../../hooks/use-api';
+
+const useNetworkStats = ({ period } = {}) => {
+  const { error, loading, response } = useApi(
+    'stats/network',
+    {
+      autoReload: true,
+      params: {
+        period,
+      },
+    },
+    [period],
+  );
+
+  return [response, loading, error];
+};
+
+export default useNetworkStats;

--- a/src/features/stats/hooks/use-relayer-stats.js
+++ b/src/features/stats/hooks/use-relayer-stats.js
@@ -1,0 +1,18 @@
+import useApi from '../../../hooks/use-api';
+
+const useRelayerStats = ({ period } = {}) => {
+  const { error, loading, response } = useApi(
+    'stats/relayer',
+    {
+      autoReload: true,
+      params: {
+        period,
+      },
+    },
+    [period],
+  );
+
+  return [response, loading, error];
+};
+
+export default useRelayerStats;

--- a/src/features/stats/models/stats-model.js
+++ b/src/features/stats/models/stats-model.js
@@ -4,12 +4,6 @@ import callApi from '../../../util/call-api';
 
 const statsModel = {
   effects: dispatch => ({
-    async fetchNetworkStats({ period }) {
-      const params = { period };
-      const stats = await callApi('stats/network', params);
-
-      dispatch.stats.updateNetworkStats({ period, stats });
-    },
     async fetchTokenStats({ period, relayer }) {
       const params = { period, relayer };
       const stats = await callApi('stats/tokens', params);
@@ -18,9 +12,6 @@ const statsModel = {
     },
   }),
   reducers: {
-    updateNetworkStats(state, { stats, period }) {
-      return { ...state, network: { ...state.network, [period]: stats } };
-    },
     updateTokenStats(state, { stats, period, relayer }) {
       const key = objectHash({ period, relayer });
 

--- a/src/features/stats/selectors.js
+++ b/src/features/stats/selectors.js
@@ -1,15 +1,5 @@
 import _ from 'lodash';
-import { createSelector } from 'reselect';
 import objectHash from 'object-hash';
-
-const getNetworkStats = createSelector(
-  [(state, props) => props.period, state => _.get(state, 'stats.network')],
-  (period, networkStats) => {
-    const stats = _.get(networkStats, `${period}`);
-
-    return stats;
-  },
-);
 
 const getTokensStats = (state, { period, relayerId }) => {
   const stats = _.get(
@@ -20,4 +10,4 @@ const getTokensStats = (state, { period, relayerId }) => {
   return stats;
 };
 
-export { getNetworkStats, getTokensStats };
+export { getTokensStats };


### PR DESCRIPTION
# Description

This PR makes a couple of small steps towards highlighting the distinction between fill and trade volume. Both stats are now shown on the dashboard, and dashboard charts have been renamed for clarity. Informative tooltips can be added in a future PR.