### PR TITLE
Handle lack of chart data gracefully

### DIFF
--- a/src/features/metrics/components/network-fees-chart.js
+++ b/src/features/metrics/components/network-fees-chart.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {
   Area,
   AreaChart,
@@ -19,6 +20,10 @@ import sharedPropTypes from '../../../prop-types';
 const formatAxisDate = date => formatDate(date, 'MMM DD');
 
 const NetworkFeesChart = ({ data, localCurrency, period }) => {
+  if (_.isEmpty(data)) {
+    return 'No data available';
+  }
+
   const paddedMetrics = padMetrics(data, period, {
     fees: '0',
     localizedFees: 0,

--- a/src/features/metrics/components/network-fees-chart.stories.js
+++ b/src/features/metrics/components/network-fees-chart.stories.js
@@ -31,4 +31,11 @@ storiesOf('Charts|NetworkFeesChart', module)
         period={TIME_PERIOD.MONTH}
       />
     );
-  });
+  })
+  .add('without any data', () => (
+    <NetworkFeesChart
+      data={[]}
+      localCurrency="USD"
+      period={TIME_PERIOD.MONTH}
+    />
+  ));

--- a/src/features/metrics/components/network-volume-chart.js
+++ b/src/features/metrics/components/network-volume-chart.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {
   Area,
   AreaChart,
@@ -48,6 +49,11 @@ class NetworkVolumeChart extends PureComponent {
 
   render() {
     const { displayCurrency, data, period, type } = this.props;
+
+    if (_.isEmpty(data)) {
+      return 'No data available';
+    }
+
     const paddedMetrics = padMetrics(data, period, {
       fills: 0,
       volume: 0,

--- a/src/features/metrics/components/network-volume-chart.stories.js
+++ b/src/features/metrics/components/network-volume-chart.stories.js
@@ -31,4 +31,11 @@ storiesOf('Charts|NetworkVolumeChart', module)
         period={TIME_PERIOD.MONTH}
       />
     );
-  });
+  })
+  .add('without any data', () => (
+    <NetworkVolumeChart
+      data={[]}
+      displayCurrency="USD"
+      period={TIME_PERIOD.MONTH}
+    />
+  ));

--- a/src/features/metrics/components/token-volume-chart.js
+++ b/src/features/metrics/components/token-volume-chart.js
@@ -39,6 +39,10 @@ class TokenVolumeChart extends PureComponent {
   render() {
     const { data, localCurrency, period, tokenSymbol } = this.props;
 
+    if (_.isEmpty(data)) {
+      return 'No data available';
+    }
+
     const paddedMetrics = padMetrics(data, period, {
       localizedVolume: 0,
       tokenVolume: '0',

--- a/src/features/metrics/components/token-volume-chart.stories.js
+++ b/src/features/metrics/components/token-volume-chart.stories.js
@@ -32,4 +32,12 @@ storiesOf('Charts|TokenVolumeChart', module)
         tokenSymbol="DAI"
       />
     );
-  });
+  })
+  .add('without any data', () => (
+    <TokenVolumeChart
+      data={[]}
+      localCurrency="USD"
+      period={TIME_PERIOD.MONTH}
+      tokenSymbol="DAI"
+    />
+  ));

--- a/src/features/relayers/components/relayer-page.js
+++ b/src/features/relayers/components/relayer-page.js
@@ -62,17 +62,17 @@ const RelayerPage = ({ screenSize, slug }) => {
               charts={[
                 {
                   component: <NetworkVolume relayerId={relayer.id} />,
-                  title: 'Network Volume',
+                  title: 'Fill Volume',
                 },
                 {
                   component: (
                     <NetworkVolume relayerId={relayer.id} type="fills" />
                   ),
-                  title: 'Fills',
+                  title: 'Fill Count',
                 },
                 {
                   component: <NetworkFees relayerId={relayer.id} />,
-                  title: 'Fees',
+                  title: 'ZRX Fees',
                 },
               ]}
               defaultPeriod={TIME_PERIOD.MONTH}

--- a/src/features/relayers/components/top-relayers-chart.js
+++ b/src/features/relayers/components/top-relayers-chart.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {
   BarChart,
   Bar,
@@ -18,6 +19,10 @@ import TopRelayersTooltip from './top-relayers-tooltip';
 const formatXAxis = share => `${numeral(share).format('0.[00]')}%`;
 
 const TopRelayersChart = ({ data, history, displayCurrency }) => {
+  if (_.isEmpty(data)) {
+    return 'No data available';
+  }
+
   const redirectToRelayer = relayer => {
     const url = buildRelayerUrl(relayer);
 

--- a/src/features/relayers/components/top-relayers-chart.stories.js
+++ b/src/features/relayers/components/top-relayers-chart.stories.js
@@ -36,4 +36,7 @@ storiesOf('Charts|TopRelayersChart', module)
     ];
 
     return <TopRelayersChart data={data} displayCurrency="USD" />;
-  });
+  })
+  .add('without data', () => (
+    <TopRelayersChart data={[]} displayCurrency="USD" />
+  ));

--- a/src/features/tokens/components/top-tokens-chart.js
+++ b/src/features/tokens/components/top-tokens-chart.js
@@ -55,6 +55,10 @@ class TopTokensChart extends PureComponent {
   render() {
     const { data, displayCurrency } = this.props;
 
+    if (_.isEmpty(data)) {
+      return 'No data available';
+    }
+
     return (
       <ResponsiveContainer>
         <BarChart data={data} margin={{ bottom: 0, left: 0, right: 0, top: 0 }}>

--- a/src/features/tokens/components/top-tokens-chart.stories.js
+++ b/src/features/tokens/components/top-tokens-chart.stories.js
@@ -42,4 +42,7 @@ storiesOf('Charts|TopTokensChart', module)
     ];
 
     return <TopTokensChart data={data} displayCurrency="GBP" />;
-  });
+  })
+  .add('without data', () => (
+    <TopTokensChart data={[]} displayCurrency="GBP" />
+  ));


### PR DESCRIPTION
# Description

Charts without any data available currently look strange, and in some circumstances cause exceptions. This PR ensures they fallback gracefully by displaying a "No data available" message.