### PR TITLE
Deprecate fill amount in favor of value

### DIFF
--- a/src/features/fills/components/fill-list.js
+++ b/src/features/fills/components/fill-list.js
@@ -52,8 +52,8 @@ const FillList = ({ excludeColumns, fills }) => {
               />
             </td>
             <td className="text-right">
-              {_.has(fill, `amount.${BASE_CURRENCY}`) ? (
-                <LocalisedAmount amount={fill.amount[BASE_CURRENCY]} />
+              {_.has(fill, `value.${BASE_CURRENCY}`) ? (
+                <LocalisedAmount amount={fill.value[BASE_CURRENCY]} />
               ) : (
                 '-'
               )}

--- a/src/features/fills/components/fill-page.js
+++ b/src/features/fills/components/fill-page.js
@@ -117,7 +117,7 @@ const FillPage = ({ fillId, screenSize }) => {
               <FillDetail title="0x Protocol">
                 v{fill.protocolVersion}
               </FillDetail>
-              {_.has(fill.amount, 'USD') && (
+              {_.has(fill.value, 'USD') && (
                 <FillDetail title="Value">
                   <LocalisedAmount amount={fill.value.USD} />
                 </FillDetail>

--- a/src/features/fills/components/recent-fills-item.js
+++ b/src/features/fills/components/recent-fills-item.js
@@ -127,8 +127,8 @@ const RecentFillsItem = ({ fill, screenSize }) => {
           <dd>{distanceInWordsToNow(fill.date)} ago</dd>
         </Metadata>
       </div>
-      {screenSize.greaterThan.xs && _.has(fill, `amount.${BASE_CURRENCY}`) ? (
-        <FillAmount amount={fill.amount[BASE_CURRENCY]} />
+      {screenSize.greaterThan.xs && _.has(fill, `value.${BASE_CURRENCY}`) ? (
+        <FillAmount amount={fill.value[BASE_CURRENCY]} />
       ) : null}
     </StyledRecentFillsItem>
   );


### PR DESCRIPTION
# Description

This PR ensures consistent use of the fill `value` field rather than a mix of `value` and `amount`. The `amount` field was renamed a while ago to `value` and will be removed in the future.