### PR TITLE
Ensure the formatToken util works with edge cases

### DIFF
--- a/src/util/format-token.js
+++ b/src/util/format-token.js
@@ -1,11 +1,31 @@
 import _ from 'lodash';
 
-const formatToken = amount => {
-  const formatted =
-    _.trimEnd(_.trimEnd(_.toNumber(amount.toString()).toFixed(6), '0'), '.') ||
-    amount;
+const trimTrailingZeroes = amount => _.trimEnd(_.trimEnd(amount, '0'), '.');
 
-  return formatted;
+const formatRecursively = (amount, precision) => {
+  if (_.isNil(amount)) {
+    return null;
+  }
+
+  const numericAmount = _.toNumber(amount);
+
+  if (Number.isNaN(numericAmount)) {
+    return null;
+  }
+
+  if (numericAmount === 0) {
+    return '0';
+  }
+
+  const formattedAmount = trimTrailingZeroes(numericAmount.toFixed(precision));
+
+  if (formattedAmount === '0') {
+    return formatRecursively(amount, precision + 1);
+  }
+
+  return formattedAmount;
 };
+
+const formatToken = amount => formatRecursively(amount, 6);
 
 export default formatToken;

--- a/src/util/format-token.test.js
+++ b/src/util/format-token.test.js
@@ -1,0 +1,41 @@
+import formatToken from './format-token';
+
+it('should return "0" when amount is 0', () => {
+  expect(formatToken(0)).toBe('0');
+});
+
+it('should return "0" when amount is "0"', () => {
+  expect(formatToken('0')).toBe('0');
+});
+
+it('should return "150" when amount is 150.000', () => {
+  expect(formatToken(150.0)).toBe('150');
+});
+
+it('should return "0.0000003" when amount is 0.000000287323296172', () => {
+  expect(formatToken(0.000000287323296172)).toBe('0.0000003');
+});
+
+it('should return "0.001" when amount is 0.001', () => {
+  expect(formatToken(0.001)).toBe('0.001');
+});
+
+it('should return "0.0000001" when amount is 0.000000087323296172', () => {
+  expect(formatToken(0.000000087323296172)).toBe('0.0000001');
+});
+
+it('should return "0.000000003" when amount is 0.000000003323296172', () => {
+  expect(formatToken(0.000000003323296172)).toBe('0.000000003');
+});
+
+it('should return null when amount is null', () => {
+  expect(formatToken(null)).toBeNull();
+});
+
+it('should return null when amount is undefined', () => {
+  expect(formatToken(undefined)).toBeNull();
+});
+
+it('should return null when amount is "fubar"', () => {
+  expect(formatToken('fubar')).toBeNull();
+});


### PR DESCRIPTION
# Description

This PR updates the formatToken util to ensure it works properly in a number of edge cases:

1) When the amount being formatted is precise to more than six decimal places
2) When the amount is null/undefined
3) When the amount is NaN