### PR TITLE
Introduce address page

### DIFF
--- a/src/components/content-header.js
+++ b/src/components/content-header.js
@@ -42,9 +42,11 @@ const ContentHeader = ({ breadcrumbItems, title }) => (
         <TitleContainer>
           <Title>{title}</Title>
         </TitleContainer>
-        <BreadcrumbContainer>
-          <Breadcrumb items={breadcrumbItems} />
-        </BreadcrumbContainer>
+        {breadcrumbItems.length > 0 ? (
+          <BreadcrumbContainer>
+            <Breadcrumb items={breadcrumbItems} />
+          </BreadcrumbContainer>
+        ) : null}
       </Row>
     </Container>
   </StyledContentHeader>
@@ -56,8 +58,12 @@ ContentHeader.propTypes = {
       title: PropTypes.string.isRequired,
       url: PropTypes.string.isRequired,
     }),
-  ).isRequired,
+  ),
   title: PropTypes.string.isRequired,
+};
+
+ContentHeader.defaultProps = {
+  breadcrumbItems: [],
 };
 
 export default ContentHeader;

--- a/src/components/page-layout.js
+++ b/src/components/page-layout.js
@@ -22,7 +22,7 @@ const StyledPageLayout = styled.div`
 
 const PageLayout = ({ breadcrumbItems, centered, children, title }) => (
   <StyledPageLayout>
-    {breadcrumbItems.length > 0 ? (
+    {title ? (
       <ContentHeader breadcrumbItems={breadcrumbItems} title={title} />
     ) : null}
     <ContentBody centered={centered}>{children}</ContentBody>

--- a/src/components/routes.js
+++ b/src/components/routes.js
@@ -4,6 +4,7 @@ import React from 'react';
 
 import AnalyticsRoute from './analytics-route';
 import createPageRoute from '../util/create-page-route';
+import getAddressesRoutes from '../features/addresses/get-routes';
 import getDashboardRoutes from '../features/dashboard/get-dashboard-routes';
 import getFillsRoutes from '../features/fills/get-routes';
 import getNewsRoutes from '../features/news/get-routes';
@@ -18,6 +19,7 @@ const routes = _.flatten([
   getRelayersRoutes(),
   getSearchRoutes(),
   getTokensRoutes(),
+  getAddressesRoutes(),
   { key: '404', loader: () => import('./page-not-found') },
 ]);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,6 +18,7 @@ const DATE_FORMAT = {
 const GENESIS_DATE = parseDate('2017-08-15T00:00:00Z');
 
 const URL = {
+  ADDRESS: '/addresses/:address',
   DASHBOARD: '/',
   FILL: '/fills/:id',
   FILLS: '/fills',

--- a/src/features/addresses/components/__snapshots__/address-link.test.js.snap
+++ b/src/features/addresses/components/__snapshots__/address-link.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render an address link 1`] = `
+.c0 {
+  color: #3f4ac3;
+  cursor: pointer;
+}
+
+.c0:hover {
+  color: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<a
+  class="c0"
+  href="/addresses/0xb14232b0204b2f7bb6ba5aff59ef36030f7fe38b"
+>
+  Hello World
+</a>
+`;

--- a/src/features/addresses/components/address-link.js
+++ b/src/features/addresses/components/address-link.js
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { URL } from '../../../constants';
+import Link from '../../../components/link';
+
+const AddressLink = ({ address, children }) => (
+  <Link href={URL.ADDRESS.replace(':address', address)}>{children}</Link>
+);
+
+AddressLink.propTypes = {
+  address: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default AddressLink;

--- a/src/features/addresses/components/address-link.test.js
+++ b/src/features/addresses/components/address-link.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { renderWithRouter } from '../../../test-util/react';
+import AddressLink from './address-link';
+
+it('should render an address link', () => {
+  const { container } = renderWithRouter(
+    <AddressLink address="0xb14232b0204b2f7bb6ba5aff59ef36030f7fe38b">
+      Hello World
+    </AddressLink>,
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/src/features/addresses/components/address-page.js
+++ b/src/features/addresses/components/address-page.js
@@ -1,0 +1,56 @@
+import { mapProps } from 'recompose';
+import { Helmet } from 'react-helmet';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { TIME_PERIOD } from '../../../constants';
+import { media } from '../../../styles/util';
+import AddressMetrics from '../../metrics/components/address-metrics';
+import Card from '../../../components/card';
+import ChartsContainer from '../../../components/charts-container';
+import Fills from '../../fills/components/fills';
+import PageLayout from '../../../components/page-layout';
+
+const AddressPage = ({ address }) => (
+  <>
+    <Helmet>
+      <title>{`Address: ${address}`}</title>
+    </Helmet>
+    <PageLayout title={`Address: ${address}`}>
+      <ChartsContainer
+        charts={[
+          {
+            component: <AddressMetrics address={address} />,
+            title: 'Fill Volume',
+          },
+        ]}
+        css={`
+          margin: 0 0 1.25em 0;
+
+          ${media.greaterThan('lg')`
+              margin: 0 0 2em 0;
+            `}
+        `}
+        defaultPeriod={TIME_PERIOD.YEAR}
+        periods={[
+          { label: '24H', value: TIME_PERIOD.DAY },
+          { label: '7D', value: TIME_PERIOD.WEEK },
+          { label: '1M', value: TIME_PERIOD.MONTH },
+          { label: '1Y', value: TIME_PERIOD.YEAR },
+          { label: 'ALL', value: TIME_PERIOD.ALL },
+        ]}
+      />
+      <Card css="flex-grow: 1;">
+        <Fills filter={{ address }} />
+      </Card>
+    </PageLayout>
+  </>
+);
+
+AddressPage.propTypes = {
+  address: PropTypes.string.isRequired,
+};
+
+export default mapProps(({ match }) => ({
+  address: match.params.address,
+}))(AddressPage);

--- a/src/features/addresses/get-routes.js
+++ b/src/features/addresses/get-routes.js
@@ -1,0 +1,7 @@
+import { URL } from '../../constants';
+
+const getRoutes = () => [
+  { loader: () => import('./components/address-page'), path: URL.ADDRESS },
+];
+
+export default getRoutes;

--- a/src/features/fills/components/fill-page.js
+++ b/src/features/fills/components/fill-page.js
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import { colors } from '../../../styles/constants';
 import { DATE_FORMAT, URL, ZRX_TOKEN } from '../../../constants';
 import { media } from '../../../styles/util';
+import AddressLink from '../../addresses/components/address-link';
 import AssetLabel from './asset-label';
 import buildFillUrl from '../util/build-fill-url';
 import buildSearchUrl from '../../search/util/build-search-url';
@@ -121,14 +122,14 @@ const FillPage = ({ fillId, screenSize }) => {
                 </FillDetail>
               )}
               <FillDetail title="Maker Address">
-                <EthereumAddressLink address={fill.makerAddress}>
+                <AddressLink address={fill.makerAddress}>
                   {fill.makerAddress}
-                </EthereumAddressLink>
+                </AddressLink>
               </FillDetail>
               <FillDetail title="Taker Address">
-                <EthereumAddressLink address={fill.takerAddress}>
+                <AddressLink address={fill.takerAddress}>
                   {fill.takerAddress}
-                </EthereumAddressLink>
+                </AddressLink>
               </FillDetail>
               <FillDetail title="Maker Assets">
                 <FillAssetsList

--- a/src/features/metrics/components/address-metrics-chart.js
+++ b/src/features/metrics/components/address-metrics-chart.js
@@ -1,0 +1,110 @@
+import _ from 'lodash';
+import {
+  Area,
+  AreaChart,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from 'recharts';
+import { format as formatDate } from 'date-fns';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import { colors } from '../../../styles/constants';
+import AddressMetricsTooltip from './address-metrics-tooltip';
+import formatCurrency from '../../../util/format-currency';
+import padMetrics from '../util/pad-metrics';
+import sharedPropTypes from '../../../prop-types';
+
+const formatAxisDate = date => formatDate(date, 'MMM DD');
+
+class AddressMetricsChart extends PureComponent {
+  constructor() {
+    super();
+
+    this.formatValue = this.formatValue.bind(this);
+  }
+
+  formatValue(value) {
+    if (value === 0) {
+      return '';
+    }
+
+    const { localCurrency } = this.props;
+
+    return formatCurrency(value, localCurrency, true);
+  }
+
+  render() {
+    const { data, localCurrency, period } = this.props;
+
+    if (_.isEmpty(data)) {
+      return 'No data available';
+    }
+
+    const paddedMetrics = padMetrics(data, period, {
+      fillCount: 0,
+      fillVolume: 0,
+    });
+
+    const sanitizedData = _.map(paddedMetrics, dataPoint => ({
+      ...dataPoint,
+      date: dataPoint.date.toISOString(),
+    }));
+
+    return (
+      <ResponsiveContainer>
+        <AreaChart
+          data={sanitizedData}
+          margin={{ bottom: 0, left: 0, right: 0, top: 0 }}
+        >
+          <Area
+            animationDuration={0}
+            dataKey="fillVolume"
+            fill={colors.periwinkleGray}
+            fillOpacity={1}
+            stroke={colors.indigo}
+            strokeOpacity={0.6}
+            strokeWidth={2}
+            type="monotone"
+          />
+          <XAxis
+            axisLine={false}
+            dataKey="date"
+            minTickGap={60}
+            tick={{ fill: 'currentColor', fontSize: '0.9em' }}
+            tickFormatter={formatAxisDate}
+            tickLine={false}
+          />
+          <YAxis
+            axisLine={false}
+            dataKey="fillVolume"
+            minTickGap={20}
+            mirror
+            padding={{ top: 25 }}
+            tick={{ fill: 'currentColor', fontSize: '0.9em' }}
+            tickFormatter={this.formatValue}
+            tickLine={false}
+          />
+          <Tooltip
+            content={<AddressMetricsTooltip localCurrency={localCurrency} />}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    );
+  }
+}
+
+AddressMetricsChart.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      date: PropTypes.object.isRequired,
+      fillVolume: PropTypes.number.isRequired,
+    }),
+  ).isRequired,
+  localCurrency: PropTypes.string.isRequired,
+  period: sharedPropTypes.timePeriod.isRequired,
+};
+
+export default AddressMetricsChart;

--- a/src/features/metrics/components/address-metrics-tooltip.js
+++ b/src/features/metrics/components/address-metrics-tooltip.js
@@ -1,0 +1,42 @@
+import _ from 'lodash';
+import { format as formatDate } from 'date-fns';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import ChartTooltip from '../../../components/chart-tooltip';
+import formatCurrency from '../../../util/format-currency';
+
+const AddressMetricsTooltip = ({ localCurrency, payload }) => {
+  if (_.isEmpty(payload)) {
+    return null;
+  }
+
+  const { date, fillCount, fillVolume } = payload[0].payload;
+
+  return (
+    <ChartTooltip
+      items={[
+        {
+          label: 'fill count',
+          value: fillCount,
+        },
+        {
+          label: `fill volume (${localCurrency})`,
+          value: formatCurrency(fillVolume, localCurrency),
+        },
+      ]}
+      title={formatDate(date, 'MMMM Do YYYY, hh:mm A')}
+    />
+  );
+};
+
+AddressMetricsTooltip.propTypes = {
+  localCurrency: PropTypes.string.isRequired,
+  payload: PropTypes.array,
+};
+
+AddressMetricsTooltip.defaultProps = {
+  payload: undefined,
+};
+
+export default AddressMetricsTooltip;

--- a/src/features/metrics/components/address-metrics.js
+++ b/src/features/metrics/components/address-metrics.js
@@ -1,0 +1,60 @@
+import { compose } from 'recompose';
+import { connect } from 'react-redux';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  getDisplayCurrency,
+  getConversionRate,
+} from '../../currencies/selectors';
+import AsyncAddressMetricsChart from './async-address-metrics-chart';
+import LoadingIndicator from '../../../components/loading-indicator';
+import sharedPropTypes from '../../../prop-types';
+import useAddressMetrics from '../hooks/use-address-metrics';
+
+const AddressMetrics = ({
+  address,
+  conversionRate,
+  displayCurrency,
+  period,
+}) => {
+  const metrics = useAddressMetrics(address, { period });
+
+  if (metrics.loading || conversionRate === undefined) {
+    return <LoadingIndicator centered />;
+  }
+
+  const data = metrics.data.map(metric => ({
+    date: new Date(metric.date),
+    fillCount: metric.fillCount,
+    fillVolume: metric.fillVolume.USD * conversionRate,
+  }));
+
+  return (
+    <AsyncAddressMetricsChart
+      data={data}
+      localCurrency={displayCurrency}
+      period={period}
+    />
+  );
+};
+
+AddressMetrics.propTypes = {
+  address: PropTypes.string.isRequired,
+  conversionRate: PropTypes.number,
+  displayCurrency: PropTypes.string.isRequired,
+  period: sharedPropTypes.timePeriod.isRequired,
+};
+
+AddressMetrics.defaultProps = {
+  conversionRate: undefined,
+};
+
+const mapStateToProps = state => ({
+  conversionRate: getConversionRate(state),
+  displayCurrency: getDisplayCurrency(state),
+});
+
+const enhance = compose(connect(mapStateToProps));
+
+export default enhance(AddressMetrics);

--- a/src/features/metrics/components/async-address-metrics-chart.js
+++ b/src/features/metrics/components/async-address-metrics-chart.js
@@ -1,0 +1,7 @@
+import createAsyncComponent from '../../../util/create-async-component';
+
+const AsyncAddressMetricsChart = createAsyncComponent(() =>
+  import('./address-metrics-chart'),
+);
+
+export default AsyncAddressMetricsChart;

--- a/src/features/metrics/hooks/use-address-metrics.js
+++ b/src/features/metrics/hooks/use-address-metrics.js
@@ -1,0 +1,23 @@
+import useApi from '../../../hooks/use-api';
+
+const useAddressMetrics = (address, { period } = {}) => {
+  const { error, loading, response } = useApi(
+    'metrics/address',
+    {
+      autoReload: true,
+      params: {
+        address,
+        period,
+      },
+    },
+    [address, period],
+  );
+
+  return {
+    data: response,
+    error,
+    loading,
+  };
+};
+
+export default useAddressMetrics;


### PR DESCRIPTION
# Description

This PR introduces a new address page which serves as the dashboard for maker/taker addresses. This page can be used to browse transactions related to a particular maker/taker and view metrics.

Individual fills link to this page and an addresses overview page will be introduced in the future.