### PR TITLE
Add time period filter to tokens page

### DIFF
--- a/src/features/tokens/components/token-list-item-volume.js
+++ b/src/features/tokens/components/token-list-item-volume.js
@@ -9,8 +9,8 @@ import LocalisedAmount from '../../currencies/components/localised-amount';
 import TokenAmount from './token-amount';
 
 const TokenListItemVolume = ({ token }) => {
-  const fillCount = _.get(token, 'stats.24h.fillCount', 0);
-  const volume = _.get(token, 'stats.24h.volume');
+  const fillCount = _.get(token, 'stats.fillCount', 0);
+  const volume = _.get(token, 'stats.fillVolume');
 
   if (fillCount === 0) {
     return '-';

--- a/src/features/tokens/components/token-list-item.js
+++ b/src/features/tokens/components/token-list-item.js
@@ -8,6 +8,7 @@ import { colors } from '../../../styles/constants';
 import FillLink from '../../fills/components/fill-link';
 import formatDate from '../../../util/format-date';
 import LocalisedAmount from '../../currencies/components/localised-amount';
+import Number from '../../../components/number';
 import TokenImage from './token-image';
 import TokenLink from './token-link';
 import TokenListItemVolume from './token-list-item-volume';
@@ -21,53 +22,47 @@ const LastTradeLink = styled(FillLink)`
   }
 `;
 
-const TokenListItem = ({ position, token }) => {
-  const fillCount = _.get(token, 'stats.24h.fillCount', 0);
-
-  return (
-    <tr className={fillCount === 0 ? 'faded' : undefined}>
-      <td className="align-middle">{position}</td>
-      <td className="align-middle">
-        <TokenLink address={token.address}>
-          <TokenImage imageUrl={token.imageUrl} />
-        </TokenLink>
-      </td>
-      <td width="99%">
-        <TokenLink address={token.address}>
-          {token.name || 'Unknown Token'}
-        </TokenLink>
-        <br />
-        {token.symbol || token.address}
-      </td>
-      <td className="align-middle" css="text-align: right;">
-        {_.has(token, 'price.last') ? (
-          <LastTradeLink fillId={token.lastTrade.id}>
-            <LocalisedAmount amount={token.price.last} />
-            <br />
-            <span
-              css={`
-                font-size: 0.8rem;
-                color: ${fillCount === 0
-                  ? colors.santasGray
-                  : colors.stormGray};
-              `}
-            >
-              {formatDate(token.lastTrade.date, DATE_FORMAT.RELATIVE)} ago
-            </span>
-          </LastTradeLink>
-        ) : (
-          '-'
-        )}
-      </td>
-      <td className="align-middle" css="text-align: right;">
-        {fillCount === 0 ? '-' : fillCount}
-      </td>
-      <td className="align-middle" css="text-align: right;">
-        <TokenListItemVolume token={token} />
-      </td>
-    </tr>
-  );
-};
+const TokenListItem = ({ position, token }) => (
+  <tr>
+    <td className="align-middle">{position}</td>
+    <td className="align-middle">
+      <TokenLink address={token.address}>
+        <TokenImage imageUrl={token.imageUrl} />
+      </TokenLink>
+    </td>
+    <td width="99%">
+      <TokenLink address={token.address}>
+        {token.name || 'Unknown Token'}
+      </TokenLink>
+      <br />
+      {token.symbol || token.address}
+    </td>
+    <td className="align-middle" css="text-align: right;">
+      {_.has(token, 'price.last') ? (
+        <LastTradeLink fillId={token.lastTrade.id}>
+          <LocalisedAmount amount={token.price.last} />
+          <br />
+          <span
+            css={`
+              font-size: 0.8rem;
+              color: ${colors.stormGray};
+            `}
+          >
+            {formatDate(token.lastTrade.date, DATE_FORMAT.RELATIVE)} ago
+          </span>
+        </LastTradeLink>
+      ) : (
+        '-'
+      )}
+    </td>
+    <td className="align-middle" css="text-align: right;">
+      <Number>{token.stats.fillCount}</Number>
+    </td>
+    <td className="align-middle" css="text-align: right;">
+      <TokenListItemVolume token={token} />
+    </td>
+  </tr>
+);
 
 TokenListItem.propTypes = {
   position: PropTypes.number.isRequired,

--- a/src/features/tokens/components/token-list.js
+++ b/src/features/tokens/components/token-list.js
@@ -1,21 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { TIME_PERIOD } from '../../../constants';
 import Paginator from '../../../components/paginator';
-import prettyPeriod from '../../../util/pretty-period';
-import sharedPropTypes from '../../../prop-types';
 import tokensPropTypes from '../prop-types';
 import TokenListItem from './token-list-item';
-
-const DEFAULT_PERIOD = TIME_PERIOD.DAY;
 
 const TokenList = ({
   onPageChange,
   page,
   pageCount,
   pageSize,
-  period,
   recordCount,
   tokens,
 }) => {
@@ -29,12 +23,8 @@ const TokenList = ({
             <th>#</th>
             <th colSpan="2">Token</th>
             <th css="text-align: right;">Last Price</th>
-            <th css="text-align: right;">
-              Fill Count ({prettyPeriod(period)})
-            </th>
-            <th css="text-align: right;">
-              Fill Volume ({prettyPeriod(period)})
-            </th>
+            <th css="text-align: right;">Fills</th>
+            <th css="text-align: right;">Volume</th>
           </tr>
         </thead>
         <tbody>
@@ -64,13 +54,11 @@ TokenList.propTypes = {
   page: PropTypes.number.isRequired,
   pageCount: PropTypes.number.isRequired,
   pageSize: PropTypes.number.isRequired,
-  period: sharedPropTypes.timePeriod,
   recordCount: PropTypes.number.isRequired,
   tokens: PropTypes.arrayOf(tokensPropTypes.tokenWithStats),
 };
 
 TokenList.defaultProps = {
-  period: DEFAULT_PERIOD,
   tokens: undefined,
 };
 

--- a/src/features/tokens/components/token-page.js
+++ b/src/features/tokens/components/token-page.js
@@ -4,9 +4,8 @@ import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { TIME_PERIOD, URL } from '../../../constants';
+import { TIME_PERIOD } from '../../../constants';
 import { media } from '../../../styles/util';
-import buildTokenUrl from '../util/build-token-url';
 import Card from '../../../components/card';
 import ChartsContainer from '../../../components/charts-container';
 import Fills from '../../fills/components/fills';
@@ -30,13 +29,6 @@ const TokenPage = ({ tokenAddress }) => {
         </title>
       </Helmet>
       <PageLayout
-        breadcrumbItems={[
-          { title: 'Tokens', url: URL.TOKENS },
-          {
-            title: _.has(token, 'name') ? token.name : 'Unknown Token',
-            url: buildTokenUrl(tokenAddress),
-          },
-        ]}
         title={_.has(token, 'name') ? token.name : `Token: ${token.address}`}
       >
         {token ? (

--- a/src/features/tokens/components/token-page.js
+++ b/src/features/tokens/components/token-page.js
@@ -16,13 +16,9 @@ import TokenVolume from '../../metrics/components/token-volume';
 import useToken from '../hooks/use-token';
 
 const TokenPage = ({ tokenAddress }) => {
-  const { data: token, error, loading } = useToken(tokenAddress);
+  const [token, loadingToken] = useToken(tokenAddress);
 
-  if (error) {
-    throw error;
-  }
-
-  if (loading) {
+  if (loadingToken) {
     return <LoadingPage />;
   }
 

--- a/src/features/tokens/hooks/use-token.js
+++ b/src/features/tokens/hooks/use-token.js
@@ -7,7 +7,11 @@ const useToken = tokenAddress => {
     [tokenAddress],
   );
 
-  return { data: response, error, loading };
+  if (error) {
+    throw error;
+  }
+
+  return [response, loading];
 };
 
 export default useToken;

--- a/src/features/tokens/hooks/use-tokens.js
+++ b/src/features/tokens/hooks/use-tokens.js
@@ -1,0 +1,26 @@
+import _ from 'lodash';
+
+import useApi from '../../../hooks/use-api';
+
+const useTokens = (options = {}) => {
+  const { error, loading, response } = useApi(
+    'tokens',
+    {
+      autoReload: options.autoReload,
+      params: _.pick(options, ['limit', 'page', 'statsPeriod']),
+    },
+    Object.values(options),
+  );
+  const { limit, page, pageCount, tokens, total } = response || {};
+
+  if (error) {
+    throw error;
+  }
+
+  return [
+    { items: tokens, page, pageCount, pageSize: limit, recordCount: total },
+    loading,
+  ];
+};
+
+export default useTokens;


### PR DESCRIPTION
# Description

This PR updates the tokens page to include a time period filter. This allows users to view traded tokens with their associated stats for a number of different time periods.