### PR TITLE
Delimit thousands when formatting token amounts

### DIFF
--- a/src/features/fills/components/asset-amount.js
+++ b/src/features/fills/components/asset-amount.js
@@ -1,10 +1,10 @@
 import _ from 'lodash';
 import React from 'react';
 
-import formatToken from '../../../util/format-token';
+import formatTokenAmount from '../../../util/format-token-amount';
 
 const AssetAmount = ({ asset }) =>
   _.isString(asset.amount) &&
-  asset.type !== 'erc-721' && <>{formatToken(asset.amount)} </>;
+  asset.type !== 'erc-721' && <>{formatTokenAmount(asset.amount)} </>;
 
 export default AssetAmount;

--- a/src/features/metrics/components/network-fees-tooltip.js
+++ b/src/features/metrics/components/network-fees-tooltip.js
@@ -5,7 +5,7 @@ import React from 'react';
 
 import ChartTooltip from '../../../components/chart-tooltip';
 import formatCurrency from '../../../util/format-currency';
-import formatToken from '../../../util/format-token';
+import formatTokenAmount from '../../../util/format-token-amount';
 
 const NetworkFeesTooltip = ({ localCurrency, payload }) => {
   if (_.isEmpty(payload)) {
@@ -23,7 +23,7 @@ const NetworkFeesTooltip = ({ localCurrency, payload }) => {
         },
         {
           label: 'fees (ZRX)',
-          value: `${formatToken(fees)} ZRX`,
+          value: `${formatTokenAmount(fees)} ZRX`,
         },
       ]}
       title={formatDate(date, 'MMMM Do YYYY, hh:mm A')}

--- a/src/features/metrics/components/token-volume-tooltip.js
+++ b/src/features/metrics/components/token-volume-tooltip.js
@@ -5,7 +5,7 @@ import React from 'react';
 
 import ChartTooltip from '../../../components/chart-tooltip';
 import formatCurrency from '../../../util/format-currency';
-import formatToken from '../../../util/format-token';
+import formatTokenAmount from '../../../util/format-token-amount';
 
 const TokenVolumeTooltip = ({ localCurrency, payload, tokenSymbol }) => {
   if (_.isEmpty(payload)) {
@@ -23,7 +23,8 @@ const TokenVolumeTooltip = ({ localCurrency, payload, tokenSymbol }) => {
         },
         {
           label: `volume (${tokenSymbol || 'token'})`,
-          value: tokenVolume !== null ? formatToken(tokenVolume) : 'Unknown',
+          value:
+            tokenVolume !== null ? formatTokenAmount(tokenVolume) : 'Unknown',
         },
       ]}
       title={formatDate(date, 'MMMM Do YYYY, hh:mm A')}

--- a/src/features/tokens/components/token-amount.js
+++ b/src/features/tokens/components/token-amount.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import formatToken from '../../../util/format-token';
+import formatTokenAmount from '../../../util/format-token-amount';
 import TokenLink from './token-link';
 
 const TokenAmount = ({ amount, linked, token }) => {
@@ -11,11 +11,11 @@ const TokenAmount = ({ amount, linked, token }) => {
 
   return linked ? (
     <span title={`${amount} ${token.symbol}`}>
-      {formatToken(amount)}{' '}
+      {formatTokenAmount(amount)}{' '}
       <TokenLink address={token.address}>{token.symbol}</TokenLink>
     </span>
   ) : (
-    `${formatToken(amount)} ${token.symbol}`
+    `${formatTokenAmount(amount)} ${token.symbol}`
   );
 };
 

--- a/src/features/tokens/components/token-list-item-volume.js
+++ b/src/features/tokens/components/token-list-item-volume.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { BASE_CURRENCY } from '../../currencies/constants';
 import { colors } from '../../../styles/constants';
-import formatToken from '../../../util/format-token';
+import formatTokenAmount from '../../../util/format-token-amount';
 import LocalisedAmount from '../../currencies/components/localised-amount';
 import TokenAmount from './token-amount';
 
@@ -23,7 +23,7 @@ const TokenListItemVolume = ({ token }) => {
 
     return (
       <>
-        {formatToken(volume.token)} {token.symbol}
+        {formatTokenAmount(volume.token)} {token.symbol}
       </>
     );
   }

--- a/src/features/tokens/components/top-tokens-tooltip.js
+++ b/src/features/tokens/components/top-tokens-tooltip.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import ChartTooltip from '../../../components/chart-tooltip';
-import formatToken from '../../../util/format-token';
+import formatTokenAmount from '../../../util/format-token-amount';
 import LocalisedAmount from '../../currencies/components/localised-amount';
 
 const TopTokensTooltip = ({ currency, payload }) => {
@@ -28,7 +28,7 @@ const TopTokensTooltip = ({ currency, payload }) => {
         },
         {
           label: `volume (${token.symbol})`,
-          value: formatToken(tokenVolume),
+          value: formatTokenAmount(tokenVolume),
         },
       ]}
       title={token.name}

--- a/src/util/format-token-amount.js
+++ b/src/util/format-token-amount.js
@@ -28,6 +28,6 @@ const formatRecursively = (amount, precision) => {
   });
 };
 
-const formatToken = amount => formatRecursively(amount, 6);
+const formatTokenAmount = amount => formatRecursively(amount, 6);
 
-export default formatToken;
+export default formatTokenAmount;

--- a/src/util/format-token-amount.test.js
+++ b/src/util/format-token-amount.test.js
@@ -1,45 +1,45 @@
-import formatToken from './format-token';
+import formatTokenAmount from './format-token-amount';
 
 it('should return "0" when amount is 0', () => {
-  expect(formatToken(0)).toBe('0');
+  expect(formatTokenAmount(0)).toBe('0');
 });
 
 it('should return "0" when amount is "0"', () => {
-  expect(formatToken('0')).toBe('0');
+  expect(formatTokenAmount('0')).toBe('0');
 });
 
 it('should return "150" when amount is 150.000', () => {
-  expect(formatToken(150.0)).toBe('150');
+  expect(formatTokenAmount(150.0)).toBe('150');
 });
 
 it('should return "150,000" when amount is 150000.000', () => {
-  expect(formatToken(150000.0)).toBe('150,000');
+  expect(formatTokenAmount(150000.0)).toBe('150,000');
 });
 
 it('should return "0.0000003" when amount is 0.000000287323296172', () => {
-  expect(formatToken(0.000000287323296172)).toBe('0.0000003');
+  expect(formatTokenAmount(0.000000287323296172)).toBe('0.0000003');
 });
 
 it('should return "0.001" when amount is 0.001', () => {
-  expect(formatToken(0.001)).toBe('0.001');
+  expect(formatTokenAmount(0.001)).toBe('0.001');
 });
 
 it('should return "0.0000001" when amount is 0.000000087323296172', () => {
-  expect(formatToken(0.000000087323296172)).toBe('0.0000001');
+  expect(formatTokenAmount(0.000000087323296172)).toBe('0.0000001');
 });
 
 it('should return "0.000000003" when amount is 0.000000003323296172', () => {
-  expect(formatToken(0.000000003323296172)).toBe('0.000000003');
+  expect(formatTokenAmount(0.000000003323296172)).toBe('0.000000003');
 });
 
 it('should return null when amount is null', () => {
-  expect(formatToken(null)).toBeNull();
+  expect(formatTokenAmount(null)).toBeNull();
 });
 
 it('should return null when amount is undefined', () => {
-  expect(formatToken(undefined)).toBeNull();
+  expect(formatTokenAmount(undefined)).toBeNull();
 });
 
 it('should return null when amount is "fubar"', () => {
-  expect(formatToken('fubar')).toBeNull();
+  expect(formatTokenAmount('fubar')).toBeNull();
 });

--- a/src/util/format-token.js
+++ b/src/util/format-token.js
@@ -23,7 +23,9 @@ const formatRecursively = (amount, precision) => {
     return formatRecursively(amount, precision + 1);
   }
 
-  return formattedAmount;
+  return Number(formattedAmount).toLocaleString('en', {
+    maximumSignificantDigits: 21,
+  });
 };
 
 const formatToken = amount => formatRecursively(amount, 6);

--- a/src/util/format-token.test.js
+++ b/src/util/format-token.test.js
@@ -12,6 +12,10 @@ it('should return "150" when amount is 150.000', () => {
   expect(formatToken(150.0)).toBe('150');
 });
 
+it('should return "150,000" when amount is 150000.000', () => {
+  expect(formatToken(150000.0)).toBe('150,000');
+});
+
 it('should return "0.0000003" when amount is 0.000000287323296172', () => {
   expect(formatToken(0.000000287323296172)).toBe('0.0000003');
 });


### PR DESCRIPTION
# Description

This PR ensures that the thousands separator is included when formatting token amounts. This helps to improve readability.