### PR TITLE
Update useApi hook to handle cancellation of in-flight requests

### DIFF
--- a/config/jest/setup.js
+++ b/config/jest/setup.js
@@ -1,2 +1,4 @@
 import 'jest-dom/extend-expect';
 import 'jest-styled-components'; // eslint-disable-line import/no-unassigned-import
+
+process.env.REACT_APP_API_ENDPOINT = 'https://api.0xtracker.com';

--- a/src/hooks/use-api.js
+++ b/src/hooks/use-api.js
@@ -1,11 +1,15 @@
 import _ from 'lodash';
 import { useEffect, useState } from 'react';
+import axios, { CancelToken } from 'axios';
 
-import callApi from '../util/call-api';
 import AutoReload from '../util/auto-reload';
+import buildApiUrl from '../util/build-api-url';
 
 const useApi = (method, options = {}) => {
-  const [state, setState] = useState({ loading: true });
+  const [state, setState] = useState({
+    cancelRequest: _.noop,
+    loading: true,
+  });
 
   const opts = _.defaults({}, options, {
     autoReload: false,
@@ -13,31 +17,53 @@ const useApi = (method, options = {}) => {
     version: 1,
   });
 
-  useEffect(() => {
-    setState({ loading: true });
+  const url = buildApiUrl(method, opts.params, { version: opts.version });
 
-    const fetchData = async () => {
-      const response = await callApi(method, opts.params, {
-        version: opts.version,
+  useEffect(
+    () => {
+      // Cancel any previous in-flight requests
+      state.cancelRequest();
+
+      const source = CancelToken.source();
+
+      setState({
+        ...state,
+        cancelRequest: source.cancel,
+        loading: true,
+        response: undefined,
       });
 
-      setState({ loading: false, response });
-    };
+      const fetchData = async () => {
+        const response = await axios.get(url, {
+          cancelToken: source.token,
+        });
 
-    fetchData()
-      .then(() => {
-        if (opts.autoReload) {
-          AutoReload.addListener(fetchData);
-        }
-      })
-      .catch(error => {
-        // Stash the error so that it can be rethrown in render scope
-        setState({ error, loading: false });
-      });
+        setState({ ...state, loading: false, response: response.data });
+      };
 
-    // Ensure auto-reload stops when the component unmounts
-    return () => AutoReload.removeListener(fetchData);
-  }, [method, opts.version, opts.autoReload, ...Object.values(opts.params)]);
+      fetchData()
+        .then(() => {
+          // Only subscribe to auto-reload once the first fetch was successful
+          if (opts.autoReload) {
+            AutoReload.addListener(fetchData);
+          }
+        })
+        .catch(error => {
+          if (axios.isCancel(error)) {
+            // Ignore cancellation errors because they're deliberate
+          } else {
+            // Stash the error so that it can be rethrown in render scope
+            setState({ ...state, error });
+          }
+        });
+
+      // Ensure auto-reload stops when the component unmounts
+      return () => AutoReload.removeListener(fetchData);
+    },
+
+    // Re-run the effect if any of these parameters change
+    [opts.autoReload, url],
+  );
 
   // Bail out if the API call failed
   if (state.error) {

--- a/src/util/build-api-url.js
+++ b/src/util/build-api-url.js
@@ -1,0 +1,18 @@
+import _ from 'lodash';
+import { flow, join, keys, map, omitBy } from 'lodash/fp';
+
+const buildApiUrl = (method, params, opts) => {
+  const options = _.defaults({}, opts, { version: 1 });
+  const endpoint = process.env.REACT_APP_API_ENDPOINT;
+  const querystring = flow([
+    omitBy(value => value === undefined),
+    keys,
+    map(key => `${key}=${params[key]}`),
+    join('&'),
+  ])(params);
+  const url = `${endpoint}/v${options.version}/${method}?${querystring}`;
+
+  return url;
+};
+
+export default buildApiUrl;

--- a/src/util/build-api-url.js
+++ b/src/util/build-api-url.js
@@ -4,15 +4,19 @@ import { flow, join, keys, map, omitBy } from 'lodash/fp';
 const buildApiUrl = (method, params, opts) => {
   const options = _.defaults({}, opts, { version: 1 });
   const endpoint = process.env.REACT_APP_API_ENDPOINT;
-  const querystring = flow([
+  const queryParams = flow([
     omitBy(value => value === undefined),
     keys,
     map(key => `${key}=${params[key]}`),
     join('&'),
   ])(params);
-  const url = `${endpoint}/v${options.version}/${method}?${querystring}`;
+  const query = queryParams.length > 0 ? `?${queryParams}` : '';
 
-  return url;
+  if (options.version === 1) {
+    return `${endpoint}/${method}${query}`;
+  }
+
+  return `${endpoint}/v${options.version}/${method}${query}`;
 };
 
 export default buildApiUrl;

--- a/src/util/build-api-url.test.js
+++ b/src/util/build-api-url.test.js
@@ -1,0 +1,67 @@
+import buildApiUrl from './build-api-url';
+
+describe('build api url', () => {
+  it('should build V1 api url by default', () => {
+    const url = buildApiUrl('relayers');
+
+    expect(url).toBe('https://api.0xtracker.com/relayers');
+  });
+
+  it('should build V1 api url without parameters', () => {
+    const url = buildApiUrl('relayers', undefined, { version: 1 });
+
+    expect(url).toBe('https://api.0xtracker.com/relayers');
+  });
+
+  it('should build V1 api url with a single parameter', () => {
+    const url = buildApiUrl(
+      'relayers',
+      { statsPeriod: 'week' },
+      { version: 1 },
+    );
+
+    expect(url).toBe('https://api.0xtracker.com/relayers?statsPeriod=week');
+  });
+
+  it('should build V1 api url with multiple parameters', () => {
+    const url = buildApiUrl(
+      'relayers',
+      {
+        excludeInactive: true,
+        statsPeriod: 'week',
+      },
+      { version: 1 },
+    );
+
+    expect(url).toBe(
+      'https://api.0xtracker.com/relayers?excludeInactive=true&statsPeriod=week',
+    );
+  });
+
+  it('should build V2 api url without parameters', () => {
+    const url = buildApiUrl('tokens', undefined, { version: 2 });
+
+    expect(url).toBe('https://api.0xtracker.com/v2/tokens');
+  });
+
+  it('should build V2 api url with a single parameter', () => {
+    const url = buildApiUrl('tokens', { statsPeriod: 'week' }, { version: 2 });
+
+    expect(url).toBe('https://api.0xtracker.com/v2/tokens?statsPeriod=week');
+  });
+
+  it('should build V2 api url with multiple parameters', () => {
+    const url = buildApiUrl(
+      'tokens',
+      {
+        statsPeriod: 'week',
+        type: 'erc-20',
+      },
+      { version: 2 },
+    );
+
+    expect(url).toBe(
+      'https://api.0xtracker.com/v2/tokens?statsPeriod=week&type=erc-20',
+    );
+  });
+});

--- a/src/util/call-api.js
+++ b/src/util/call-api.js
@@ -1,17 +1,9 @@
-import _ from 'lodash';
-import { flow, join, keys, map, omitBy } from 'lodash/fp';
 import axios from 'axios';
 
+import buildApiUrl from './build-api-url';
+
 const callApi = async (method, params, opts) => {
-  const options = _.defaults({}, opts, { version: 1 });
-  const endpoint = process.env.REACT_APP_API_ENDPOINT;
-  const querystring = flow([
-    omitBy(value => value === undefined),
-    keys,
-    map(key => `${key}=${params[key]}`),
-    join('&'),
-  ])(params);
-  const url = `${endpoint}/v${options.version}/${method}?${querystring}`;
+  const url = buildApiUrl(method, params, opts);
   const response = await axios.get(url);
 
   return response.data;


### PR DESCRIPTION
# Description

This PR updates the useApi hook to handle cancellation of in-flight requests. This fixes an edge case whereby the user may see data from a previous long-running request, causing the UI and data to be out of sync.