### PR TITLE
Stop rebasing stale Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-  "extends": ["github>0xTracker/renovate-config-0x-tracker"]
+  "extends": ["github>0xTracker/renovate-config-0x-tracker"],
+  "rebaseStalePrs": true
 }


### PR DESCRIPTION
# Description

This PR updates the Renovate config to prevent rebasing of stale PRs. This will reduce the number of builds going through Netlify where we're currently over the monthly limit being introduced in December.