### PR TITLE
Add word-break to page layout title

### DIFF
--- a/src/components/page-title-block.js
+++ b/src/components/page-title-block.js
@@ -17,7 +17,7 @@ const StyledContentHeader = styled.div`
   `};
 `;
 
-const TitleContainer = styled(Col).attrs({ sm: 6, xs: 12 })`
+const TitleContainer = styled(Col)`
   align-items: center;
   display: flex;
   margin: 0 0 1.25rem;
@@ -34,6 +34,7 @@ const Title = styled.h1`
   margin: 0;
   padding: 0 0 1.25rem;
   width: 100%;
+  word-break: break-all;
 
   ${media.greaterThan('sm')`
     border: none;


### PR DESCRIPTION
Some page layout titles overflows.

Before:
![image](https://user-images.githubusercontent.com/10157660/66700329-ca806480-ecf7-11e9-8a43-c1f63fc464b3.png)
After:
![image](https://user-images.githubusercontent.com/10157660/66700346-dff58e80-ecf7-11e9-949e-72a96e00bf8a.png)

*Notes:*
TitleContainer had media queries but I don't know why. I removed them and checked every page that uses PageLayout with title and everything looks good. If it's needed for something please write me
