### PR TITLE
Fix spacing in recent fills card

### DIFF
--- a/src/features/fills/components/__snapshots__/fill-list-assets.test.js.snap
+++ b/src/features/fills/components/__snapshots__/fill-list-assets.test.js.snap
@@ -9,7 +9,6 @@ exports[`fill list assets component should link ERC-20 asset 1`] = `
     href="/tokens/0x12345"
   >
     WETH
-     
   </a>
 </div>
 `;
@@ -23,8 +22,7 @@ exports[`fill list assets component should link ERC-721 asset 1`] = `
     target="_blank"
   >
     CK
-     
-    #
+     #
     999
   </a>
 </div>
@@ -35,15 +33,13 @@ exports[`fill list assets component should render for ERC-20 asset 1`] = `
   150
    
   WETH
-   
 </div>
 `;
 
 exports[`fill list assets component should render for ERC-721 asset 1`] = `
 <div>
   CK
-   
-  #
+   #
   999
 </div>
 `;

--- a/src/features/fills/components/__snapshots__/recent-fills-list.test.js.snap
+++ b/src/features/fills/components/__snapshots__/recent-fills-list.test.js.snap
@@ -1,0 +1,226 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render an assortment of fills 1`] = `
+<DocumentFragment>
+  <div
+    class="sc-EHOje looXiP"
+  >
+    <div
+      class="recent-fills-item__StyledRecentFillsItem-sc-1yc2z6o-0 gZyfwm"
+    >
+      <a
+        class="link__InternalLink-sc-1m1n17q-1 kIJfjy sc-bdVaJa jTGwSJ"
+        href="/relayers/token-trove"
+      >
+        <img
+          alt=""
+          class="sc-bwzfXH hgpraj"
+          src="https://0xtracker.com/assets/logos/token-trove.png"
+        />
+      </a>
+      <div
+        class="sc-ifAKCX fkortk"
+      >
+        <h4
+          class="recent-fills-item__Heading-sc-1yc2z6o-2 cfJjoe"
+        >
+          <a
+            class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+            href="/fills/5dd96f9d250aa512ae416656"
+          >
+            CARD #41011762 ⇋ 0.19 WETH
+          </a>
+        </h4>
+        <dl
+          class="recent-fills-item__Metadata-sc-1yc2z6o-1 hkWbiM"
+        >
+          <dt>
+            Relayer
+          </dt>
+          <dd>
+            <a
+              class="link__InternalLink-sc-1m1n17q-1 kIJfjy recent-fills-item__SourceLink-sc-1yc2z6o-4 exkLNx"
+              href="/relayers/token-trove"
+            >
+              TokenTrove
+            </a>
+          </dd>
+          <dt>
+            Date
+          </dt>
+          <dd>
+            18 minutes ago
+          </dd>
+        </dl>
+      </div>
+      <span
+        class="recent-fills-item__FillAmount-sc-1yc2z6o-3 ksoyPo"
+      >
+        $29.24
+      </span>
+    </div>
+    <div
+      class="recent-fills-item__StyledRecentFillsItem-sc-1yc2z6o-0 gZyfwm"
+    >
+      <a
+        class="link__InternalLink-sc-1m1n17q-1 kIJfjy sc-bdVaJa jTGwSJ"
+        href="/relayers/token-trove"
+      >
+        <img
+          alt=""
+          class="sc-bwzfXH hgpraj"
+          src="https://0xtracker.com/assets/logos/token-trove.png"
+        />
+      </a>
+      <div
+        class="sc-ifAKCX fkortk"
+      >
+        <h4
+          class="recent-fills-item__Heading-sc-1yc2z6o-2 cfJjoe"
+        >
+          <a
+            class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+            href="/fills/5dd96f6d250aa512ae40bad3"
+          >
+            Unknown #122150411 ⇋ 0.975 WETH
+          </a>
+        </h4>
+        <dl
+          class="recent-fills-item__Metadata-sc-1yc2z6o-1 hkWbiM"
+        >
+          <dt>
+            Relayer
+          </dt>
+          <dd>
+            <a
+              class="link__InternalLink-sc-1m1n17q-1 kIJfjy recent-fills-item__SourceLink-sc-1yc2z6o-4 exkLNx"
+              href="/relayers/token-trove"
+            >
+              TokenTrove
+            </a>
+          </dd>
+          <dt>
+            Date
+          </dt>
+          <dd>
+            19 minutes ago
+          </dd>
+        </dl>
+      </div>
+      <span
+        class="recent-fills-item__FillAmount-sc-1yc2z6o-3 ksoyPo"
+      >
+        $150.06
+      </span>
+    </div>
+    <div
+      class="recent-fills-item__StyledRecentFillsItem-sc-1yc2z6o-0 gZyfwm"
+    >
+      <a
+        class="link__InternalLink-sc-1m1n17q-1 kIJfjy sc-bdVaJa jTGwSJ"
+        href="/relayers/star-bit"
+      >
+        <img
+          alt=""
+          class="sc-bwzfXH hgpraj"
+          src="https://0xtracker.com/assets/logos/starbit.png"
+        />
+      </a>
+      <div
+        class="sc-ifAKCX fkortk"
+      >
+        <h4
+          class="recent-fills-item__Heading-sc-1yc2z6o-2 cfJjoe"
+        >
+          <a
+            class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+            href="/fills/5dd96f3f250aa512ae3fb34a"
+          >
+            0.0403 WETH ⇋ 2,693 SBT
+          </a>
+        </h4>
+        <dl
+          class="recent-fills-item__Metadata-sc-1yc2z6o-1 hkWbiM"
+        >
+          <dt>
+            Relayer
+          </dt>
+          <dd>
+            <a
+              class="link__InternalLink-sc-1m1n17q-1 kIJfjy recent-fills-item__SourceLink-sc-1yc2z6o-4 exkLNx"
+              href="/relayers/star-bit"
+            >
+              STAR BIT
+            </a>
+          </dd>
+          <dt>
+            Date
+          </dt>
+          <dd>
+            20 minutes ago
+          </dd>
+        </dl>
+      </div>
+      <span
+        class="recent-fills-item__FillAmount-sc-1yc2z6o-3 ksoyPo"
+      >
+        $6.20
+      </span>
+    </div>
+    <div
+      class="recent-fills-item__StyledRecentFillsItem-sc-1yc2z6o-0 gZyfwm"
+    >
+      <a
+        class="link__InternalLink-sc-1m1n17q-1 kIJfjy sc-bdVaJa jTGwSJ"
+        href="/relayers/star-bit"
+      >
+        <img
+          alt=""
+          class="sc-bwzfXH hgpraj"
+          src="https://0xtracker.com/assets/logos/starbit.png"
+        />
+      </a>
+      <div
+        class="sc-ifAKCX fkortk"
+      >
+        <h4
+          class="recent-fills-item__Heading-sc-1yc2z6o-2 cfJjoe"
+        >
+          <a
+            class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+            href="/fills/5dd96f3f250aa512ae3fb34d"
+          >
+            2,693 SBT ⇋ Unknown
+          </a>
+        </h4>
+        <dl
+          class="recent-fills-item__Metadata-sc-1yc2z6o-1 hkWbiM"
+        >
+          <dt>
+            Relayer
+          </dt>
+          <dd>
+            <a
+              class="link__InternalLink-sc-1m1n17q-1 kIJfjy recent-fills-item__SourceLink-sc-1yc2z6o-4 exkLNx"
+              href="/relayers/star-bit"
+            >
+              STAR BIT
+            </a>
+          </dd>
+          <dt>
+            Date
+          </dt>
+          <dd>
+            20 minutes ago
+          </dd>
+        </dl>
+      </div>
+      <span
+        class="recent-fills-item__FillAmount-sc-1yc2z6o-3 ksoyPo"
+      >
+        $6.06
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/features/fills/components/asset-label.js
+++ b/src/features/fills/components/asset-label.js
@@ -11,7 +11,8 @@ const AssetLabel = ({ asset, condensed, linked }) => {
       : buildTokenUrl(asset.tokenAddress);
   const children = condensed ? (
     <>
-      {asset.tokenSymbol || 'Unknown'} {asset.tokenId && <>#{asset.tokenId}</>}
+      {asset.tokenSymbol || 'Unknown'}
+      {asset.tokenId && <> #{asset.tokenId}</>}
     </>
   ) : (
     <>

--- a/src/features/fills/components/recent-fills-item.js
+++ b/src/features/fills/components/recent-fills-item.js
@@ -109,7 +109,7 @@ const RecentFillsItem = ({ fill }) => {
           <FillLink fillId={fill.id}>
             <FillListAssets
               assets={_.filter(fill.assets, { traderType: 'maker' })}
-            />
+            />{' '}
             &#8651;{' '}
             <FillListAssets
               assets={_.filter(fill.assets, { traderType: 'taker' })}

--- a/src/features/fills/components/recent-fills-list.js
+++ b/src/features/fills/components/recent-fills-list.js
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import fillsPropTypes from '../prop-types';
+import RecentFillsItem from './recent-fills-item';
+
+const RecentFillsList = ({ fills }) => (
+  <div css="overflow-x: scroll">
+    {fills.map(fill => (
+      <RecentFillsItem fill={fill} key={fill.id} />
+    ))}
+  </div>
+);
+
+RecentFillsList.propTypes = {
+  fills: PropTypes.arrayOf(fillsPropTypes.partialFill).isRequired,
+};
+
+export default RecentFillsList;

--- a/src/features/fills/components/recent-fills-list.test.js
+++ b/src/features/fills/components/recent-fills-list.test.js
@@ -1,0 +1,162 @@
+import React from 'react';
+
+import { renderWithRouter } from '../../../test-util/react';
+import RecentFillsList from './recent-fills-list';
+
+it('should render an assortment of fills', () => {
+  const fills = [
+    {
+      assets: [
+        {
+          amount: '1',
+          price: {
+            USD: 29.2429,
+          },
+          tokenAddress: '0x0e3a2a1f2146d86a604adc220b4967a898d7fe07',
+          tokenId: 41011762,
+          tokenSymbol: 'CARD',
+          tokenType: 'Gods Unchained Cards',
+          traderType: 'maker',
+          type: 'erc-721',
+        },
+        {
+          amount: '0.19',
+          price: {
+            USD: 153.91,
+          },
+          tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+          tokenSymbol: 'WETH',
+          tokenType: 'Wrapped Ether',
+          traderType: 'taker',
+          type: 'erc-20',
+        },
+      ],
+      date: '2019-11-23T17:38:44.000Z',
+      feeRecipient: '0x0d056bb17ad4df5593b93a1efc29cb35ba4aa38d',
+      id: '5dd96f9d250aa512ae416656',
+      makerAddress: '0x5161e1380cd661d7d993c8a3b3e57b059ad8d7a4',
+      relayer: {
+        imageUrl: 'https://0xtracker.com/assets/logos/token-trove.png',
+        name: 'TokenTrove',
+        slug: 'token-trove',
+      },
+      status: 'successful',
+      takerAddress: '0x76481caa104b5f6bccb540dae4cefaf1c398ebea',
+      value: {
+        USD: 29.2429,
+      },
+    },
+    {
+      assets: [
+        {
+          tokenAddress: '0x0e3a2a1f2146d86a604adc220b4967a898d7fe07',
+          tokenId: 122150411,
+          traderType: 'maker',
+          type: 'erc-721',
+        },
+        {
+          amount: '0.975',
+          price: {
+            USD: 153.91,
+          },
+          tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+          tokenSymbol: 'WETH',
+          tokenType: 'Wrapped Ether',
+          traderType: 'taker',
+          type: 'erc-20',
+        },
+      ],
+      date: '2019-11-23T17:38:01.000Z',
+      feeRecipient: '0x0d056bb17ad4df5593b93a1efc29cb35ba4aa38d',
+      id: '5dd96f6d250aa512ae40bad3',
+      makerAddress: '0x55a9c5180dcafc98d99d3f3e4b248e9156b12ac1',
+      relayer: {
+        imageUrl: 'https://0xtracker.com/assets/logos/token-trove.png',
+        name: 'TokenTrove',
+        slug: 'token-trove',
+      },
+      status: 'successful',
+      takerAddress: '0x76481caa104b5f6bccb540dae4cefaf1c398ebea',
+      value: {
+        USD: 150.06225,
+      },
+    },
+    {
+      assets: [
+        {
+          amount: '0.04030042144',
+          price: {
+            USD: 153.87,
+          },
+          tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+          tokenSymbol: 'WETH',
+          tokenType: 'Wrapped Ether',
+          traderType: 'maker',
+          type: 'erc-20',
+        },
+        {
+          amount: '2693',
+          price: {
+            USD: 0.002302646062745191,
+          },
+          tokenAddress: '0x503f9794d6a6bb0df8fbb19a2b3e2aeab35339ad',
+          tokenSymbol: 'SBT',
+          tokenType: 'Star Bit Token',
+          traderType: 'taker',
+          type: 'erc-20',
+        },
+      ],
+      date: '2019-11-23T17:37:28.000Z',
+      feeRecipient: '0x8124071f810d533ff63de61d0c98db99eeb99d64',
+      id: '5dd96f3f250aa512ae3fb34a',
+      makerAddress: '0x49cb7cedb65fcfeabb4d1dcb24d8da202d370eda',
+      relayer: {
+        imageUrl: 'https://0xtracker.com/assets/logos/starbit.png',
+        name: 'STAR BIT',
+        slug: 'star-bit',
+      },
+      status: 'successful',
+      takerAddress: '0x0681e844593a051e2882ec897ecd5444efe19ff2',
+      value: {
+        USD: 6.2010258469728,
+      },
+    },
+    {
+      assets: [
+        {
+          amount: '2693',
+          price: {
+            USD: 0.0022505749888953757,
+          },
+          tokenAddress: '0x503f9794d6a6bb0df8fbb19a2b3e2aeab35339ad',
+          tokenSymbol: 'SBT',
+          tokenType: 'Star Bit Token',
+          traderType: 'maker',
+          type: 'erc-20',
+        },
+        {
+          tokenAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+          traderType: 'taker',
+          type: 'erc-20',
+        },
+      ],
+      date: '2019-11-23T17:37:28.000Z',
+      feeRecipient: '0x8124071f810d533ff63de61d0c98db99eeb99d64',
+      id: '5dd96f3f250aa512ae3fb34d',
+      makerAddress: '0x3997d0f55d1daa549e95c240bc6353636f4cf974',
+      relayer: {
+        imageUrl: 'https://0xtracker.com/assets/logos/starbit.png',
+        name: 'STAR BIT',
+        slug: 'star-bit',
+      },
+      status: 'successful',
+      takerAddress: '0x0681e844593a051e2882ec897ecd5444efe19ff2',
+      value: {
+        USD: 6.060798445095247,
+      },
+    },
+  ];
+  const { asFragment } = renderWithRouter(<RecentFillsList fills={fills} />);
+
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/src/features/fills/components/recent-fills-list.test.js
+++ b/src/features/fills/components/recent-fills-list.test.js
@@ -1,7 +1,16 @@
 import React from 'react';
+import timekeeper from 'timekeeper';
 
 import { renderWithRouter } from '../../../test-util/react';
 import RecentFillsList from './recent-fills-list';
+
+beforeAll(() => {
+  timekeeper.freeze('2019-11-23T17:57:00Z');
+});
+
+afterAll(() => {
+  timekeeper.reset();
+});
 
 it('should render an assortment of fills', () => {
   const fills = [

--- a/src/features/fills/components/recent-fills.js
+++ b/src/features/fills/components/recent-fills.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import LoadingIndicator from '../../../components/loading-indicator';
-import RecentFillsItem from './recent-fills-item';
+import RecentFillsList from './recent-fills-list';
 import useFills from '../hooks/use-fills';
 
 const RecentFills = ({ filter }) => {
@@ -11,11 +11,7 @@ const RecentFills = ({ filter }) => {
   return loading ? (
     <LoadingIndicator centered />
   ) : (
-    <div css="overflow-x: scroll">
-      {fills.items.map(fill => (
-        <RecentFillsItem fill={fill} key={fill.id} />
-      ))}
-    </div>
+    <RecentFillsList fills={fills.items} />
   );
 };
 

--- a/src/features/fills/prop-types.js
+++ b/src/features/fills/prop-types.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import tokensPropTypes from '../tokens/prop-types';
 import tradersPropTypes from '../traders/prop-types';
 
-const fillPropType = PropTypes.shape({
+const fillShape = PropTypes.shape({
   assets: PropTypes.arrayOf(
     PropTypes.shape({
       amount: PropTypes.string.isRequired,
@@ -45,6 +45,32 @@ const fillPropType = PropTypes.shape({
   value: PropTypes.shape({ USD: PropTypes.number.isRequired }),
 });
 
-const propTypes = { fill: fillPropType };
+const partialFillShape = PropTypes.shape({
+  assets: PropTypes.arrayOf(
+    PropTypes.shape({
+      amount: PropTypes.string,
+      price: PropTypes.shape({ USD: PropTypes.number.isRequired }),
+      tokenAddress: PropTypes.string.isRequired,
+      tokenSymbol: PropTypes.string,
+      tokenType: PropTypes.string,
+      traderType: tradersPropTypes.traderType.isRequired,
+      type: tokensPropTypes.tokenType.isRequired,
+    }),
+  ).isRequired,
+  date: PropTypes.string.isRequired,
+  feeRecipient: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+  makerAddress: PropTypes.string.isRequired,
+  relayer: PropTypes.shape({
+    imageUrl: PropTypes.string,
+    name: PropTypes.string.isRequired,
+    slug: PropTypes.string.isRequired,
+  }),
+  status: PropTypes.string.isRequired,
+  takerAddress: PropTypes.string.isRequired,
+  value: PropTypes.shape({ USD: PropTypes.number.isRequired }),
+});
+
+const propTypes = { fill: fillShape, partialFill: partialFillShape };
 
 export default propTypes;


### PR DESCRIPTION
This PR fixes a small issue with the spacing after ERC-721 assets in the recent fills card. I've also increased test coverage to avoid a regression in the future.