### PR TITLE
Add filtering parameters to fills page

### DIFF
--- a/src/components/error-boundary.js
+++ b/src/components/error-boundary.js
@@ -50,32 +50,49 @@ class ErrorBoundary extends React.PureComponent {
     const { error } = this.state;
     const { children } = this.props;
 
-    if (error) {
+    if (error === undefined) {
+      return children;
+    }
+
+    if (error.response !== undefined && error.response.status === 400) {
       return (
         <>
           <GlobalStyles />
           <Wrapper>
             <ErrorMessage css="padding: 0 4rem;">
-              <H1>Unexpected Error</H1>
+              <H1>Invalid Parameters</H1>
               <Lead>
-                Oops, an unexpected error occurred whilst trying to display this
-                page.
+                The URL parameters passed to this page were incorrect. Please
+                check and try again.
               </Lead>
-              <TryAgainButton
-                onClick={() => {
-                  window.location.reload();
-                }}
-                type="button"
-              >
-                Reload Page
-              </TryAgainButton>
             </ErrorMessage>
           </Wrapper>
         </>
       );
     }
 
-    return children;
+    return (
+      <>
+        <GlobalStyles />
+        <Wrapper>
+          <ErrorMessage css="padding: 0 4rem;">
+            <H1>Unexpected Error</H1>
+            <Lead>
+              Oops, an unexpected error occurred whilst trying to display this
+              page.
+            </Lead>
+            <TryAgainButton
+              onClick={() => {
+                window.location.reload();
+              }}
+              type="button"
+            >
+              Reload Page
+            </TryAgainButton>
+          </ErrorMessage>
+        </Wrapper>
+      </>
+    );
   }
 }
 

--- a/src/components/no-results-message.js
+++ b/src/components/no-results-message.js
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+
+const StyledNoResultsMessage = styled.div`
+  align-items: center;
+  display: flex;
+  flex-grow: 1;
+  justify-content: center;
+  flex-shrink: 1;
+  padding: 2rem;
+`;
+
+const NoResultsMessage = ({ children }) => (
+  <StyledNoResultsMessage>
+    <p css="font-size: 1.3rem; text-align: center; word-break: break-word;">
+      {children}
+    </p>
+  </StyledNoResultsMessage>
+);
+
+NoResultsMessage.propTypes = {
+  children: PropTypes.string.isRequired,
+};
+
+export default NoResultsMessage;

--- a/src/features/fills/components/fills-page.js
+++ b/src/features/fills/components/fills-page.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
@@ -11,11 +12,26 @@ import PageLayout from '../../../components/page-layout';
 const FillsPage = ({ history, location }) => {
   const params = new URLSearchParams(location.search);
   const page = Number(params.get('page')) || 1;
+  const status = params.get('status');
+  const dateFrom = params.get('dateFrom');
+  const dateTo = params.get('dateTo');
+  const protocolVersion =
+    params.get('protocolVersion') === null
+      ? null
+      : _.toNumber(params.get('protocolVersion'));
+  const token = params.get('token');
+  const relayer = params.get('relayer');
 
   const onPageChange = useCallback(newPage => {
     history.push(
       buildUrl(URL.FILLS, {
+        dateFrom,
+        dateTo,
         page: newPage,
+        protocolVersion,
+        relayer,
+        status,
+        token,
       }),
     );
   }, []);
@@ -27,7 +43,18 @@ const FillsPage = ({ history, location }) => {
       </Helmet>
       <PageLayout title="Browse Fills">
         <Card fullHeight>
-          <Fills onPageChange={onPageChange} page={page} />
+          <Fills
+            filter={{
+              dateFrom,
+              dateTo,
+              protocolVersion,
+              relayer,
+              status,
+              token,
+            }}
+            onPageChange={onPageChange}
+            page={page}
+          />
         </Card>
       </PageLayout>
     </>

--- a/src/features/fills/components/fills.js
+++ b/src/features/fills/components/fills.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import fillsPropTypes from '../prop-types';
 import LoadingIndicator from '../../../components/loading-indicator';
+import NoResultsMessage from '../../../components/no-results-message';
 import PagedFillList from './paged-fill-list';
 import useFills from '../hooks/use-fills';
 
@@ -14,9 +16,19 @@ const Fills = ({ excludeColumns, filter, page, onPageChange }) => {
 
   const { items, pageCount, pageSize, recordCount } = fills;
 
-  return loading ? (
-    <LoadingIndicator centered />
-  ) : (
+  if (loading) {
+    return <LoadingIndicator centered />;
+  }
+
+  if (items.length === 0) {
+    return (
+      <NoResultsMessage>
+        No fills were found matching the selected filters.
+      </NoResultsMessage>
+    );
+  }
+
+  return (
     <PagedFillList
       excludeColumns={excludeColumns}
       fills={items}
@@ -33,6 +45,10 @@ Fills.propTypes = {
   excludeColumns: PropTypes.arrayOf(PropTypes.oneOf(['relayer'])),
   filter: PropTypes.shape({
     address: PropTypes.string,
+    dateFrom: PropTypes.string,
+    dateTo: PropTypes.string,
+    protocolVersion: PropTypes.number,
+    status: fillsPropTypes.status,
     token: PropTypes.string,
   }),
   onPageChange: PropTypes.func.isRequired,

--- a/src/features/fills/hooks/use-fills.js
+++ b/src/features/fills/hooks/use-fills.js
@@ -1,15 +1,20 @@
 import useApi from '../../../hooks/use-api';
 
 const useFills = (options = {}) => {
-  const { address, relayer, token } = options.filter || {};
+  const { address, dateFrom, dateTo, protocolVersion, relayer, status, token } =
+    options.filter || {};
 
   const [response, loading] = useApi('fills', {
     autoReload: options.autoReload,
     params: {
+      dateFrom,
+      dateTo,
       limit: options.limit,
       page: options.page,
+      protocolVersion,
       q: address,
       relayer,
+      status,
       token,
     },
   });

--- a/src/features/fills/prop-types.js
+++ b/src/features/fills/prop-types.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import tokensPropTypes from '../tokens/prop-types';
 import tradersPropTypes from '../traders/prop-types';
 
+const fillStatusPropType = PropTypes.oneOf(['failed', 'pending', 'successful']);
+
 const fillShape = PropTypes.shape({
   assets: PropTypes.arrayOf(
     PropTypes.shape({
@@ -31,7 +33,7 @@ const fillShape = PropTypes.shape({
     slug: PropTypes.string.isRequired,
   }),
   senderAddress: PropTypes.string.isRequired,
-  status: PropTypes.string.isRequired,
+  status: fillStatusPropType.isRequired,
   takerAddress: PropTypes.string.isRequired,
   takerFee: PropTypes.shape({
     USD: PropTypes.number,
@@ -66,11 +68,15 @@ const partialFillShape = PropTypes.shape({
     name: PropTypes.string.isRequired,
     slug: PropTypes.string.isRequired,
   }),
-  status: PropTypes.string.isRequired,
+  status: fillStatusPropType.isRequired,
   takerAddress: PropTypes.string.isRequired,
   value: PropTypes.shape({ USD: PropTypes.number.isRequired }),
 });
 
-const propTypes = { fill: fillShape, partialFill: partialFillShape };
+const propTypes = {
+  fill: fillShape,
+  partialFill: partialFillShape,
+  status: fillStatusPropType,
+};
 
 export default propTypes;

--- a/src/features/search/components/search-results.js
+++ b/src/features/search/components/search-results.js
@@ -1,17 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled from 'styled-components';
 
+import NoResultsMessage from '../../../components/no-results-message';
 import PagedFillList from '../../fills/components/paged-fill-list';
-
-const NoResults = styled.div`
-  align-items: center;
-  display: flex;
-  flex-grow: 1;
-  justify-content: center;
-  flex-shrink: 1;
-  padding: 2rem;
-`;
 
 const SearchResults = ({
   changingPage,
@@ -25,12 +16,10 @@ const SearchResults = ({
 }) => {
   if (fills.length === 0) {
     return (
-      <NoResults>
-        <p css="font-size: 1.3rem; text-align: center; word-break: break-word;">
-          No results found for <br />
-          <span css="font-weight: bold;">&quot;{searchQuery}&quot;</span>
-        </p>
-      </NoResults>
+      <NoResultsMessage>
+        No results found for <br />
+        <span css="font-weight: bold;">&quot;{searchQuery}&quot;</span>
+      </NoResultsMessage>
     );
   }
 


### PR DESCRIPTION
This PR introduces querystring parameters to the fills page for filtering. The parameters that have been added are:

* dateFrom
* dateTo
* protocolVersion
* relayer
* status
* token

These parameters will be used in a future PR to build out a filtering UI.