### PR TITLE
Add protocol adoption chart to network overview

### DIFF
--- a/src/features/metrics/components/async-protocol-metrics-chart.js
+++ b/src/features/metrics/components/async-protocol-metrics-chart.js
@@ -1,0 +1,7 @@
+import createAsyncComponent from '../../../util/create-async-component';
+
+const AsyncProtocolMetricsChart = createAsyncComponent(() =>
+  import('./protocol-metrics-chart'),
+);
+
+export default AsyncProtocolMetricsChart;

--- a/src/features/metrics/components/protocol-metrics-chart.js
+++ b/src/features/metrics/components/protocol-metrics-chart.js
@@ -1,0 +1,109 @@
+import _ from 'lodash';
+import {
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Brush,
+} from 'recharts';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { colors } from '../../../styles/constants';
+import { DATE_FORMAT } from '../../../constants';
+import ChartPlaceholder from '../../../components/chart-placeholder';
+import formatDate from '../../../util/format-date';
+import NetworkMetricsTooltip from './network-metrics-tooltip';
+
+const formatAxisDate = date => formatDate(date, DATE_FORMAT.COMPACT);
+
+const formatPercentage = amount => `${Math.floor(amount)}%`;
+
+// eslint-disable-next-line react/display-name
+const ProtocolMetricsChart = React.memo(({ currency, data, onBrushChange }) => {
+  if (_.isEmpty(data)) {
+    return <ChartPlaceholder>No data available</ChartPlaceholder>;
+  }
+
+  const sanitizedData = data.map(dataPoint => ({
+    ...dataPoint,
+    date: dataPoint.date.toISOString(),
+  }));
+
+  const COLORS = [colors.martinique, colors.lavenderGray, colors.haiti];
+
+  return (
+    <ResponsiveContainer>
+      <LineChart
+        data={sanitizedData}
+        margin={{ bottom: 0, left: 0, right: 0, top: 0 }}
+      >
+        {[1, 2, 3].map((protocolVersion, index) => (
+          <Line
+            animationDuration={0}
+            dataKey={dataPoint => {
+              const total = _.sum(dataPoint.stats.map(x => x.fillVolume));
+              const stat = dataPoint.stats.find(
+                x => x.protocolVersion === protocolVersion,
+              );
+
+              if (stat === undefined) {
+                return 0;
+              }
+
+              return (stat.fillVolume / total) * 100;
+            }}
+            key={protocolVersion}
+            type="monotone"
+            connectNulls={true}
+            dot={false}
+            stroke={COLORS[index]}
+            strokeWidth={2}
+          />
+        ))}
+        <XAxis
+          axisLine={false}
+          dataKey="date"
+          minTickGap={60}
+          tick={{ fill: 'currentColor', fontSize: '0.9em' }}
+          tickFormatter={formatAxisDate}
+          tickLine={false}
+        />
+        <YAxis
+          axisLine={false}
+          domain={[0, 100]}
+          mirror
+          tick={{ fill: 'currentColor', fontSize: '0.9em' }}
+          tickFormatter={formatPercentage}
+          tickLine={false}
+        />
+        <Tooltip content={<NetworkMetricsTooltip currency={currency} />} />
+        <Brush
+          dataKey="date"
+          height={30}
+          onChange={onBrushChange}
+          stroke={colors.periwinkleGray}
+          tickFormatter={formatAxisDate}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+});
+
+ProtocolMetricsChart.propTypes = {
+  currency: PropTypes.string.isRequired,
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      date: PropTypes.instanceOf(Date).isRequired,
+    }),
+  ).isRequired,
+  onBrushChange: PropTypes.func,
+};
+
+ProtocolMetricsChart.defaultProps = {
+  onBrushChange: undefined,
+};
+
+export default ProtocolMetricsChart;

--- a/src/features/metrics/components/protocol-metrics-tooltip.js
+++ b/src/features/metrics/components/protocol-metrics-tooltip.js
@@ -1,0 +1,55 @@
+import _ from 'lodash';
+import numeral from 'numeral';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { DATE_FORMAT } from '../../../constants';
+import ChartTooltip from '../../../components/chart-tooltip';
+import formatCurrency from '../../../util/format-currency';
+import formatDate from '../../../util/format-date';
+
+const ProtocolMetricsTooltip = ({ currency, payload }) => {
+  if (_.isEmpty(payload)) {
+    return null;
+  }
+
+  const { date, stats } = payload[0].payload;
+
+  return (
+    <ChartTooltip
+      items={_.sortBy(stats, 'protocolVersion')
+        .filter(stat => stat.fillCount > 0)
+        .map(stat => ({
+          label: `v${stat.protocolVersion}`,
+          value: `${formatCurrency(stat.fillVolume, currency)} / ${numeral(
+            stat.fillCount,
+          ).format('0,0')} fills`,
+        }))}
+      title={formatDate(date, DATE_FORMAT.STANDARD)}
+    />
+  );
+};
+
+ProtocolMetricsTooltip.propTypes = {
+  currency: PropTypes.string.isRequired,
+  payload: PropTypes.arrayOf(
+    PropTypes.shape({
+      payload: PropTypes.shape({
+        date: PropTypes.string.isRequired,
+        stats: PropTypes.arrayOf(
+          PropTypes.shape({
+            fillCount: PropTypes.number.isRequired,
+            fillVolume: PropTypes.number.isRequired,
+            protocolVersion: PropTypes.number.isRequired,
+          }),
+        ).isRequired,
+      }).isRequired,
+    }),
+  ),
+};
+
+ProtocolMetricsTooltip.defaultProps = {
+  payload: undefined,
+};
+
+export default ProtocolMetricsTooltip;

--- a/src/features/metrics/components/protocol-metrics.js
+++ b/src/features/metrics/components/protocol-metrics.js
@@ -1,0 +1,100 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+
+import { TIME_PERIOD } from '../../../constants';
+import AsyncProtocolMetricsChart from './async-protocol-metrics-chart';
+import LoadingIndicator from '../../../components/loading-indicator';
+import ResetChartButton from '../../../components/reset-chart-button';
+import useConversionRate from '../../currencies/hooks/use-conversion-rate';
+import useDisplayCurrency from '../../preferences/hooks/use-display-currency';
+import useProtocolMetrics from '../hooks/use-protocol-metrics';
+
+const Container = styled.div`
+  height: 100%;
+  position: relative;
+  width: 100%;
+`;
+
+const ProtocolMetrics = ({ period }) => {
+  const [brushActive, setBrushActive] = React.useState(false);
+  const [metrics, loading] = useProtocolMetrics(
+    { period },
+    { autoReload: !brushActive },
+  );
+  const conversionRate = useConversionRate();
+  const displayCurrency = useDisplayCurrency();
+
+  // This is a quick and dirty hack to implement brush resetting because Recharts
+  // doesn't allow us to control the brush indexes after mount. It works by modifying
+  // a chartKey value which is used as the key prop on AsyncNetworkMetricsChart below.
+  // When this key changes it will force a rerender of the chart.
+  const [chartKey, setChartKey] = React.useState(Date.now());
+  const handleResetClick = () => {
+    setBrushActive(false);
+    setChartKey(Date.now());
+  };
+
+  // The NetworkMetricsChart is designed to only rerender when one of its props changes. This
+  // is to prevent the brush position resetting when chart data hasn't changed. Because of this
+  // we must memoize the `handleBrushChange` and `data` props to ensure their references don't
+  // change each time this component rerenders (e.g. after the brushActive state changes).
+  const handleBrushChange = React.useCallback(() => {
+    setBrushActive(true);
+  }, []);
+
+  const data = React.useMemo(
+    () =>
+      (metrics || []).map(metric => ({
+        date: new Date(metric.date),
+        stats: metric.stats.map(stat => ({
+          ...stat,
+          fillVolume: (parseFloat(stat.fillVolume) || 0) * conversionRate,
+        })),
+      })),
+    [metrics, conversionRate],
+  );
+
+  if (loading || conversionRate === undefined) {
+    return <LoadingIndicator centered />;
+  }
+
+  return (
+    <Container>
+      {brushActive && (
+        <ResetChartButton
+          css="position: absolute; right: 0; z-index: 10;"
+          onClick={handleResetClick}
+        />
+      )}
+      <AsyncProtocolMetricsChart
+        currency={displayCurrency}
+        data={data}
+        key={chartKey}
+        onBrushChange={handleBrushChange}
+        period={period}
+      />
+    </Container>
+  );
+};
+
+ProtocolMetrics.propTypes = {
+  period: PropTypes.string,
+};
+
+ProtocolMetrics.defaultProps = {
+  period: TIME_PERIOD.MONTH,
+};
+
+// eslint-disable-next-line react/display-name, import/no-anonymous-default-export, react/prop-types, react/no-multi-comp
+export default ({ period, type }) => (
+  /*
+    This is a hack to ensure autoReload is reset whenever the period or type props are changed.
+    By using a key composed of period and type we can ensure the metrics component will remount
+    (and therefore reset state) whenever one of these props changes.
+
+    Ideally the autoReload state would be lifted up the component treet but I'm being lazy for
+    the time being because of the additional work involved.
+  */
+  <ProtocolMetrics key={`${period}_${type}`} period={period} type={type} />
+);

--- a/src/features/metrics/components/protocol-metrics.js
+++ b/src/features/metrics/components/protocol-metrics.js
@@ -16,10 +16,27 @@ const Container = styled.div`
   width: 100%;
 `;
 
+const determineGranularity = period => {
+  switch (period) {
+    case TIME_PERIOD.DAY:
+      return 'hour';
+    case TIME_PERIOD.WEEK:
+      return 'day';
+    case TIME_PERIOD.MONTH:
+      return 'day';
+    case TIME_PERIOD.YEAR:
+      return 'month';
+    case TIME_PERIOD.ALL:
+      return 'month';
+    default:
+      throw new Error(`Unrecognised time period: ${period}`);
+  }
+};
+
 const ProtocolMetrics = ({ period }) => {
   const [brushActive, setBrushActive] = React.useState(false);
   const [metrics, loading] = useProtocolMetrics(
-    { period },
+    { granularity: determineGranularity(period), period },
     { autoReload: !brushActive },
   );
   const conversionRate = useConversionRate();

--- a/src/features/metrics/hooks/use-protocol-metrics.js
+++ b/src/features/metrics/hooks/use-protocol-metrics.js
@@ -1,12 +1,13 @@
 import useApi from '../../../hooks/use-api';
 
 const useProtocolMetrics = (
-  { period } = {},
+  { granularity, period } = {},
   { autoReload } = { autoReload: true },
 ) =>
   useApi('metrics/protocol', {
     autoReload,
     params: {
+      granularity,
       period,
     },
   });

--- a/src/features/metrics/hooks/use-protocol-metrics.js
+++ b/src/features/metrics/hooks/use-protocol-metrics.js
@@ -1,0 +1,14 @@
+import useApi from '../../../hooks/use-api';
+
+const useProtocolMetrics = (
+  { period } = {},
+  { autoReload } = { autoReload: true },
+) =>
+  useApi('metrics/protocol', {
+    autoReload,
+    params: {
+      period,
+    },
+  });
+
+export default useProtocolMetrics;

--- a/src/features/network-overview/components/network-overview-page.js
+++ b/src/features/network-overview/components/network-overview-page.js
@@ -9,6 +9,7 @@ import { media } from '../../../styles/util';
 import ActiveTradersCard from '../../traders/components/active-traders-card';
 import NetworkOverviewStats from './network-overview-stats';
 import NetworkMetrics from '../../metrics/components/network-metrics';
+import ProtocolMetrics from '../../metrics/components/protocol-metrics';
 import PageLayout from '../../../components/page-layout';
 import TabbedCard from '../../../components/tabbed-card';
 import TimePeriodFilter from '../../../components/time-period-filter';
@@ -121,14 +122,14 @@ const NetworkOverviewPage = ({ history, location }) => {
               css="height: 360px;"
               tabs={[
                 {
+                  component: <ProtocolMetrics period={period} />,
+                  title: 'Protocol Adoption',
+                },
+                {
                   component: (
                     <NetworkMetrics period={period} type="protocolFees" />
                   ),
                   title: 'Protocol Fees',
-                },
-                {
-                  component: <div />,
-                  title: 'Protocol Adoption',
                 },
               ]}
             />

--- a/src/features/network-overview/components/top-protocols-card.js
+++ b/src/features/network-overview/components/top-protocols-card.js
@@ -10,7 +10,7 @@ import TopProtocols from './top-protocols';
 const TopProtocolsCard = ({ period }) => (
   <Card css="height: 360px;">
     <CardHeader>
-      <CardHeading>Protocol Comparison</CardHeading>
+      <CardHeading>Protocol Share</CardHeading>
     </CardHeader>
     <CardBody padded>
       <TopProtocols period={period} />

--- a/src/features/network-overview/components/top-protocols-chart.js
+++ b/src/features/network-overview/components/top-protocols-chart.js
@@ -1,17 +1,22 @@
 import _ from 'lodash';
-import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts';
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+} from 'recharts';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { colors } from '../../../styles/constants';
+import { protocolColors } from '../../../styles/constants';
 import TopProtocolsChartTooltip from './top-protocols-chart-tooltip';
 
 const TopProtocolsChart = ({ data }) => {
   if (_.isEmpty(data)) {
     return 'No data available';
   }
-
-  const COLORS = [colors.indigo, colors.martinique, colors.santasGray];
 
   return (
     <ResponsiveContainer>
@@ -20,15 +25,20 @@ const TopProtocolsChart = ({ data }) => {
           data={data}
           dataKey="fillCount"
           isAnimationActive={false}
-          label={({ protocolVersion }) => `v${protocolVersion}`}
-          labelLine
+          label={false}
           nameKey="protocolVersion"
           paddingAngle={0}
         >
-          {data.map((entry, index) => (
-            <Cell fill={COLORS[index]} key={`cell-${entry.protocolVersion}`} />
+          {data.map(entry => (
+            <Cell
+              fill={protocolColors[entry.protocolVersion]}
+              fillOpacity={0.7}
+              key={`cell-${entry.protocolVersion}`}
+              name={`v${entry.protocolVersion}`}
+            />
           ))}
         </Pie>
+        <Legend height={36} verticalAlign="top" />
         <Tooltip content={<TopProtocolsChartTooltip />} />
       </PieChart>
     </ResponsiveContainer>

--- a/src/features/network-overview/components/top-protocols.js
+++ b/src/features/network-overview/components/top-protocols.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -22,7 +23,7 @@ const TopProtocolsFooter = styled.p`
 
 const TopProtocols = ({ period }) => {
   const [protocols, loading] = useProtocols({
-    limit: 4,
+    limit: 3,
     page: 1,
     sortBy: 'fillCount',
     statsPeriod: period,
@@ -32,17 +33,20 @@ const TopProtocols = ({ period }) => {
     return <LoadingIndicator centered />;
   }
 
-  const stats = protocols.items.map(protocol => ({
-    fillCount: protocol.stats.fillCount,
-    fillVolume: protocol.stats.fillVolume,
-    protocolVersion: protocol.version,
-  }));
+  const stats = _.sortBy(
+    protocols.items.map(protocol => ({
+      fillCount: protocol.stats.fillCount,
+      fillVolume: protocol.stats.fillVolume,
+      protocolVersion: protocol.version,
+    })),
+    'protocolVersion',
+  );
 
   return (
     <>
       <AsyncTopProtocolsChart data={stats} />
       <TopProtocolsFooter>
-        Top protocols by {verbosePeriod(period)} fill count
+        Protocol share by {verbosePeriod(period)} fill count
         <AsteriskIcon css="margin-left: 0.5rem; opacity: 0.7;" size="12" />
       </TopProtocolsFooter>
     </>

--- a/src/styles/constants.js
+++ b/src/styles/constants.js
@@ -25,4 +25,10 @@ const colors = {
   white: '#fff', // light text color
 };
 
-export { breakpoints, colors };
+const protocolColors = {
+  1: colors.lavenderGray,
+  2: colors.violet,
+  3: colors.indigo,
+};
+
+export { breakpoints, colors, protocolColors };


### PR DESCRIPTION
This PR adds a protocol adoption chart to the network overview page which shows the adoption of protocol versions over time.

## Screenshots

<img width="678" alt="Screenshot 2020-02-03 at 19 10 06" src="https://user-images.githubusercontent.com/34132/73682705-d2a24c80-46b8-11ea-97ad-8d1181ee9255.png">
