### PR TITLE
Make various improvements to the network overview page

### DIFF
--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -16,6 +16,7 @@ import ResetIcon from './reset-icon';
 import RightArrowIcon from './right-arrow-icon';
 import SearchIcon from './search-icon';
 import SettingsIcon from './settings-icon';
+import TimePeriodIcon from './time-period-icon';
 import TwitterIcon from './twitter-icon';
 
 export {
@@ -36,5 +37,6 @@ export {
   RightArrowIcon,
   SearchIcon,
   SettingsIcon,
+  TimePeriodIcon,
   TwitterIcon,
 };

--- a/src/components/icons/time-period-icon.js
+++ b/src/components/icons/time-period-icon.js
@@ -1,0 +1,3 @@
+import { Time as TimePeriodIcon } from 'styled-icons/boxicons-regular/Time';
+
+export default TimePeriodIcon;

--- a/src/components/mobile-time-period-filter.js
+++ b/src/components/mobile-time-period-filter.js
@@ -1,0 +1,62 @@
+import { useClickAway } from 'react-use';
+import PropTypes from 'prop-types';
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+
+import { colors } from '../styles/constants';
+import { TimePeriodIcon } from './icons';
+import PopoutTimePeriodSelector from './popout-time-period-selector';
+import sharedPropTypes from '../prop-types';
+
+const Button = styled.button`
+  align-items: center;
+  background: ${colors.mystic};
+  border: none;
+  border-radius: 0.25rem;
+  color: currentColor;
+  display: flex;
+  height: 38px;
+  width: 38px;
+  flex-shrink: 0;
+  flex-grow: 0;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+
+  &:hover {
+    background: ${colors.mischka};
+  }
+`;
+
+const MobileTimePeriodFilter = ({ onChange, value }) => {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef();
+
+  useClickAway(wrapperRef, () => {
+    setOpen(false);
+  });
+
+  return (
+    <div ref={wrapperRef}>
+      <Button onClick={() => setOpen(!open)}>
+        <TimePeriodIcon height={22} width={22} />
+      </Button>
+      {open && (
+        <PopoutTimePeriodSelector
+          onChange={newValue => {
+            onChange(newValue);
+            setOpen(false);
+          }}
+          value={value}
+        />
+      )}
+    </div>
+  );
+};
+
+MobileTimePeriodFilter.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  value: sharedPropTypes.timePeriod.isRequired,
+};
+
+export default MobileTimePeriodFilter;

--- a/src/components/popout-time-period-selector.js
+++ b/src/components/popout-time-period-selector.js
@@ -1,0 +1,56 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+
+import { TIME_PERIOD } from '../constants';
+import AsyncSelect from './async-select';
+
+const OPTIONS = [
+  { label: 'Past 24 hours', value: TIME_PERIOD.DAY },
+  { label: 'Past week', value: TIME_PERIOD.WEEK },
+  { label: 'Past month', value: TIME_PERIOD.MONTH },
+  { label: 'Past year', value: TIME_PERIOD.YEAR },
+  { label: 'All time', value: TIME_PERIOD.ALL },
+];
+
+const StyledSelect = styled(AsyncSelect)`
+  && .Select__control {
+    display: none;
+  }
+
+  && .Select__menu {
+    position: absolute;
+    right: 0;
+    width: 200px;
+  }
+`;
+
+const PopoutTimePeriodSelector = ({ className, name, onChange, value }) => (
+  <StyledSelect
+    autoFocus
+    className={className}
+    controlShouldRenderValue={false}
+    hideSelectedOptions={false}
+    isClearable={false}
+    isSearchable={false}
+    menuIsOpen
+    name={name}
+    onChange={option => onChange(option.value, name)}
+    options={OPTIONS}
+    value={OPTIONS.find(option => option.value === value)}
+  />
+);
+
+PopoutTimePeriodSelector.propTypes = {
+  className: PropTypes.string,
+  name: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.string.isRequired,
+};
+
+PopoutTimePeriodSelector.defaultProps = {
+  className: undefined,
+  name: undefined,
+};
+
+export default PopoutTimePeriodSelector;

--- a/src/components/sub-title.js
+++ b/src/components/sub-title.js
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+import { colors } from '../styles/constants';
+
+const SubTitle = styled.small`
+  color: ${colors.stormGray};
+  display: block;
+  font-size: 0.9rem;
+  text-transform: lowercase;
+`;
+
+export default SubTitle;

--- a/src/constants.js
+++ b/src/constants.js
@@ -31,7 +31,7 @@ const URL = {
   FILL: '/fills/:id',
   FILLS: '/fills',
   HOME: '/',
-  NETWORK_OVERVIEW: '/network-overview',
+  NETWORK_INSIGHTS: '/network-insights',
   NEWS: '/news-and-updates',
   RELAYER: '/relayers/:slug',
   RELAYERS: '/relayers',

--- a/src/features/metrics/components/network-metrics-chart.js
+++ b/src/features/metrics/components/network-metrics-chart.js
@@ -73,9 +73,7 @@ const NetworkMetricsChart = React.memo(
             padding={{ top: 25 }}
             tick={{ fill: 'currentColor', fontSize: '0.9em' }}
             tickFormatter={
-              type === 'fillVolume' ||
-              type === 'tradeVolume' ||
-              type === 'protocolFees'
+              type === 'tradeVolume' || type === 'protocolFees'
                 ? formatCurrency
                 : formatCount
             }

--- a/src/features/metrics/components/network-metrics-tooltip.js
+++ b/src/features/metrics/components/network-metrics-tooltip.js
@@ -15,8 +15,6 @@ const NetworkMetricsTooltip = ({ currency, payload }) => {
 
   const {
     date,
-    fillCount,
-    fillVolume,
     protocolFees,
     protocolFeesETH,
     tradeCount,
@@ -26,14 +24,6 @@ const NetworkMetricsTooltip = ({ currency, payload }) => {
   return (
     <ChartTooltip
       items={[
-        {
-          label: 'Fill Count',
-          value: <Number>{fillCount}</Number>,
-        },
-        {
-          label: `Fill Volume (${currency})`,
-          value: formatCurrency(fillVolume, currency),
-        },
         {
           label: `Protocol Fees (${currency})`,
           value: formatCurrency(protocolFees, currency),
@@ -62,8 +52,6 @@ NetworkMetricsTooltip.propTypes = {
     PropTypes.shape({
       payload: PropTypes.shape({
         date: PropTypes.string.isRequired,
-        fillCount: PropTypes.number.isRequired,
-        fillVolume: PropTypes.number.isRequired,
         protocolFees: PropTypes.number.isRequired,
         protocolFeesETH: PropTypes.string.isRequired,
         tradeCount: PropTypes.number.isRequired,

--- a/src/features/metrics/components/network-metrics.js
+++ b/src/features/metrics/components/network-metrics.js
@@ -48,8 +48,6 @@ const NetworkMetrics = ({ period, type }) => {
     () =>
       (metrics || []).map(metric => ({
         date: new Date(metric.date),
-        fillCount: metric.fillCount,
-        fillVolume: (parseFloat(metric.fillVolume) || 0) * conversionRate,
         protocolFees:
           (parseFloat(metric.protocolFees.USD) || 0) * conversionRate,
         protocolFeesETH: metric.protocolFees.ETH,

--- a/src/features/metrics/components/protocol-metrics-chart.js
+++ b/src/features/metrics/components/protocol-metrics-chart.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { Bar, BarChart, XAxis, YAxis, Tooltip, Brush, Legend } from 'recharts';
+import { Bar, BarChart, XAxis, Tooltip, Brush, Legend } from 'recharts';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -11,7 +11,6 @@ import formatDate from '../../../util/format-date';
 import ProtocolMetricsTooltip from './protocol-metrics-tooltip';
 
 const formatAxisDate = date => formatDate(date, DATE_FORMAT.COMPACT);
-const formatPercentage = amount => `${Math.floor(amount)}%`;
 
 const getProtocols = data =>
   _.uniq(
@@ -47,13 +46,6 @@ const ProtocolMetricsChart = React.memo(({ currency, data, onBrushChange }) => {
           minTickGap={60}
           tick={{ fill: 'currentColor', fontSize: '0.9em' }}
           tickFormatter={formatAxisDate}
-          tickLine={false}
-        />
-        <YAxis
-          axisLine={false}
-          domain={[0, 100]}
-          tick={{ fill: 'currentColor', fontSize: '0.9em' }}
-          tickFormatter={formatPercentage}
           tickLine={false}
         />
         <Brush
@@ -101,8 +93,8 @@ ProtocolMetricsChart.propTypes = {
       stats: PropTypes.arrayOf(
         PropTypes.shape({
           fillCount: PropTypes.number.isRequired,
-          fillVolume: PropTypes.number.isRequired,
           protocolVersion: PropTypes.number.isRequired,
+          tradeVolume: PropTypes.number.isRequired,
         }),
       ).isRequired,
     }),

--- a/src/features/metrics/components/protocol-metrics-tooltip.js
+++ b/src/features/metrics/components/protocol-metrics-tooltip.js
@@ -21,7 +21,7 @@ const ProtocolMetricsTooltip = ({ currency, payload }) => {
         .filter(stat => stat.fillCount > 0)
         .map(stat => ({
           label: `v${stat.protocolVersion}`,
-          value: `${formatCurrency(stat.fillVolume, currency)} / ${numeral(
+          value: `${formatCurrency(stat.tradeVolume, currency)} / ${numeral(
             stat.fillCount,
           ).format('0,0')} fills`,
         }))}
@@ -39,8 +39,8 @@ ProtocolMetricsTooltip.propTypes = {
         stats: PropTypes.arrayOf(
           PropTypes.shape({
             fillCount: PropTypes.number.isRequired,
-            fillVolume: PropTypes.number.isRequired,
             protocolVersion: PropTypes.number.isRequired,
+            tradeVolume: PropTypes.number.isRequired,
           }),
         ).isRequired,
       }).isRequired,

--- a/src/features/metrics/components/protocol-metrics.js
+++ b/src/features/metrics/components/protocol-metrics.js
@@ -58,7 +58,7 @@ const ProtocolMetrics = ({ period }) => {
         date: new Date(metric.date),
         stats: metric.stats.map(stat => ({
           ...stat,
-          fillVolume: (parseFloat(stat.fillVolume) || 0) * conversionRate,
+          tradeVolume: (parseFloat(stat.tradeVolume) || 0) * conversionRate,
         })),
       })),
     [metrics, conversionRate],

--- a/src/features/network-overview/components/network-overview-page.js
+++ b/src/features/network-overview/components/network-overview-page.js
@@ -6,11 +6,15 @@ import styled from 'styled-components';
 
 import { TIME_PERIOD, URL } from '../../../constants';
 import { media } from '../../../styles/util';
+import { useCurrentBreakpoint } from '../../../responsive-utils';
 import ActiveTradersCard from '../../traders/components/active-traders-card';
+import Hidden from '../../../components/hidden';
+import MobileTimePeriodFilter from '../../../components/mobile-time-period-filter';
 import NetworkOverviewStats from './network-overview-stats';
 import NetworkMetrics from '../../metrics/components/network-metrics';
 import ProtocolMetrics from '../../metrics/components/protocol-metrics';
 import PageLayout from '../../../components/page-layout';
+import SubTitle from '../../../components/sub-title';
 import TabbedCard from '../../../components/tabbed-card';
 import TimePeriodFilter from '../../../components/time-period-filter';
 import TopRelayers from '../../relayers/components/top-relayers';
@@ -44,25 +48,46 @@ const StyledNetworkOverviewStats = styled(NetworkOverviewStats)`
   `}
 `;
 
+const periodDescriptions = {
+  [TIME_PERIOD.DAY]: 'for the last 24 hours',
+  [TIME_PERIOD.WEEK]: 'for the past week',
+  [TIME_PERIOD.MONTH]: 'for the past month',
+  [TIME_PERIOD.YEAR]: 'for the past year',
+  [TIME_PERIOD.ALL]: 'for all time',
+};
+
 const NetworkOverviewPage = ({ history, location }) => {
   const params = new URLSearchParams(location.search);
   const period = params.get('period') || TIME_PERIOD.YEAR;
+  const breakpoint = useCurrentBreakpoint();
+  const periodFilterProps = {
+    onChange: newPeriod => {
+      history.push(`${URL.NETWORK_OVERVIEW}?period=${newPeriod}`);
+    },
+    value: period,
+  };
 
   return (
     <>
-      <Helmet key="network-overview">
-        <title>Network Overview</title>
+      <Helmet key="network-insights">
+        <title>Network Insights</title>
       </Helmet>
       <PageLayout
         filter={
-          <TimePeriodFilter
-            onChange={newPeriod => {
-              history.push(`${URL.NETWORK_OVERVIEW}?period=${newPeriod}`);
-            }}
-            value={period}
-          />
+          breakpoint.lessThan('sm') ? (
+            <MobileTimePeriodFilter {...periodFilterProps} />
+          ) : (
+            <TimePeriodFilter {...periodFilterProps} />
+          )
         }
-        title="Network Overview"
+        title={
+          <span>
+            Network Insights
+            <Hidden above="xs">
+              <SubTitle>{periodDescriptions[period]}</SubTitle>
+            </Hidden>
+          </span>
+        }
       >
         <StyledNetworkOverviewStats period={period} />
         <Row>
@@ -81,18 +106,6 @@ const NetworkOverviewPage = ({ history, location }) => {
                     <NetworkMetrics period={period} type="tradeCount" />
                   ),
                   title: 'Trade Count',
-                },
-                {
-                  component: (
-                    <NetworkMetrics period={period} type="fillVolume" />
-                  ),
-                  title: 'Fill Volume',
-                },
-                {
-                  component: (
-                    <NetworkMetrics period={period} type="fillCount" />
-                  ),
-                  title: 'Fill Count',
                 },
               ]}
             />
@@ -136,10 +149,10 @@ const NetworkOverviewPage = ({ history, location }) => {
           </DashboardColumn>
         </Row>
         <Row>
-          <DashboardColumn lg={7}>
+          <DashboardColumn lastRow lg={7}>
             <ActiveTradersCard period={period} />
           </DashboardColumn>
-          <DashboardColumn lg={5}>
+          <DashboardColumn lastRow lg={5}>
             <TraderTypesCard period={period} />
           </DashboardColumn>
         </Row>

--- a/src/features/network-overview/components/network-overview-page.js
+++ b/src/features/network-overview/components/network-overview-page.js
@@ -62,7 +62,7 @@ const NetworkOverviewPage = ({ history, location }) => {
   const breakpoint = useCurrentBreakpoint();
   const periodFilterProps = {
     onChange: newPeriod => {
-      history.push(`${URL.NETWORK_OVERVIEW}?period=${newPeriod}`);
+      history.push(`${URL.NETWORK_INSIGHTS}?period=${newPeriod}`);
     },
     value: period,
   };

--- a/src/features/network-overview/components/network-overview-stats-carousel.js
+++ b/src/features/network-overview/components/network-overview-stats-carousel.js
@@ -7,7 +7,7 @@ import '../../../styles/css/slick-carousel.css';
 
 import { breakpoints } from '../../../styles/constants';
 import ActiveTradersWidget from '../../traders/components/active-traders-widget';
-import FillVolumeWidget from '../../fills/components/fill-volume-widget';
+import ProtocolFeesWidget from '../../stats/components/protocol-fees-widget';
 import TradeCountWidget from '../../fills/components/trade-count-widget';
 import TradeVolumeWidget from '../../fills/components/trade-volume-widget';
 
@@ -17,7 +17,7 @@ const CarouselStat = styled.div`
 
 const NetworkOverviewStatsCarousel = ({
   className,
-  fillVolume,
+  protocolFees,
   tradeCount,
   traderCount,
   tradeVolume,
@@ -41,16 +41,16 @@ const NetworkOverviewStatsCarousel = ({
     slidesToScroll={3}
     slidesToShow={3}
   >
-    <CarouselStat as={FillVolumeWidget} fillVolume={fillVolume} />
     <CarouselStat as={TradeVolumeWidget} volume={tradeVolume} />
     <CarouselStat as={TradeCountWidget} tradeCount={tradeCount} />
     <CarouselStat as={ActiveTradersWidget} traderCount={traderCount} />
+    <CarouselStat accumulatedFees={protocolFees} as={ProtocolFeesWidget} />
   </Slider>
 );
 
 NetworkOverviewStatsCarousel.propTypes = {
   className: PropTypes.string,
-  fillVolume: PropTypes.number,
+  protocolFees: PropTypes.number,
   tradeCount: PropTypes.number,
   tradeVolume: PropTypes.number,
   traderCount: PropTypes.number,
@@ -58,7 +58,7 @@ NetworkOverviewStatsCarousel.propTypes = {
 
 NetworkOverviewStatsCarousel.defaultProps = {
   className: undefined,
-  fillVolume: undefined,
+  protocolFees: undefined,
   tradeCount: undefined,
   tradeVolume: undefined,
   traderCount: undefined,

--- a/src/features/network-overview/components/network-overview-stats.js
+++ b/src/features/network-overview/components/network-overview-stats.js
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { useCurrentBreakpoint } from '../../../responsive-utils';
 import ActiveTradersWidget from '../../traders/components/active-traders-widget';
-import FillVolumeWidget from '../../fills/components/fill-volume-widget';
+import ProtocolFeesWidget from '../../stats/components/protocol-fees-widget';
 import sharedPropTypes from '../../../prop-types';
 import TradeCountWidget from '../../fills/components/trade-count-widget';
 import TradeVolumeWidget from '../../fills/components/trade-volume-widget';
@@ -22,16 +22,13 @@ const NetworkOverviewStats = ({ className, period }) => {
   const [traderStats] = useTraderStats({ period });
   const breakpoint = useCurrentBreakpoint();
 
-  const fillVolume = _.get(networkStats, 'fillVolume');
   const tradeCount = _.get(networkStats, 'tradeCount');
   const traderCount = _.get(traderStats, 'traderCount');
   const tradeVolume = _.get(networkStats, 'tradeVolume');
+  const protocolFees = _.get(networkStats, 'protocolFees.USD');
 
   return breakpoint.greaterThan('md') ? (
     <Row className={className}>
-      <Col lg={3} md={6}>
-        <FillVolumeWidget fillVolume={fillVolume} />
-      </Col>
       <Col lg={3} md={6}>
         <TradeVolumeWidget volume={tradeVolume} />
       </Col>
@@ -41,11 +38,14 @@ const NetworkOverviewStats = ({ className, period }) => {
       <Col lg={3} md={6}>
         <ActiveTradersWidget traderCount={traderCount} />
       </Col>
+      <Col lg={3} md={6}>
+        <ProtocolFeesWidget accumulatedFees={protocolFees} />
+      </Col>
     </Row>
   ) : (
     <AsyncNetworkOverviewStatsCarousel
       className={className}
-      fillVolume={fillVolume}
+      protocolFees={protocolFees}
       tradeCount={tradeCount}
       traderCount={traderCount}
       tradeVolume={tradeVolume}

--- a/src/features/network-overview/components/top-protocols-chart-tooltip.js
+++ b/src/features/network-overview/components/top-protocols-chart-tooltip.js
@@ -14,7 +14,7 @@ const TopProtocolsChartTooltip = ({ payload }) => {
     return null;
   }
 
-  const { protocolVersion, fillCount, fillVolume } = payload[0].payload;
+  const { protocolVersion, fillCount, tradeVolume } = payload[0].payload;
 
   return (
     <ChartTooltip
@@ -24,12 +24,12 @@ const TopProtocolsChartTooltip = ({ payload }) => {
           value: <Number>{fillCount}</Number>,
         },
         {
-          label: `Fill Volume (${displayCurrency})`,
+          label: `Volume (${displayCurrency})`,
           value:
-            fillVolume === 0 ? (
+            tradeVolume === 0 ? (
               'Unknown'
             ) : (
-              <LocalisedAmount amount={fillVolume} />
+              <LocalisedAmount amount={tradeVolume} />
             ),
         },
       ]}
@@ -43,8 +43,8 @@ TopProtocolsChartTooltip.propTypes = {
     PropTypes.shape({
       payload: PropTypes.shape({
         fillCount: PropTypes.number.isRequired,
-        fillVolume: PropTypes.number.isRequired,
         protocolVersion: PropTypes.number.isRequired,
+        tradeVolume: PropTypes.number.isRequired,
       }),
     }),
   ),

--- a/src/features/network-overview/components/top-protocols-chart.js
+++ b/src/features/network-overview/components/top-protocols-chart.js
@@ -43,8 +43,8 @@ TopProtocolsChart.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
       fillCount: PropTypes.number.isRequired,
-      fillVolume: PropTypes.number.isRequired,
       protocolVersion: PropTypes.number.isRequired,
+      tradeVolume: PropTypes.number.isRequired,
     }).isRequired,
   ).isRequired,
 };

--- a/src/features/network-overview/components/top-protocols.js
+++ b/src/features/network-overview/components/top-protocols.js
@@ -36,8 +36,8 @@ const TopProtocols = ({ period }) => {
   const stats = _.sortBy(
     protocols.items.map(protocol => ({
       fillCount: protocol.stats.fillCount,
-      fillVolume: protocol.stats.fillVolume,
       protocolVersion: protocol.version,
+      tradeVolume: protocol.stats.tradeVolume,
     })),
     'protocolVersion',
   );

--- a/src/features/network-overview/get-routes.js
+++ b/src/features/network-overview/get-routes.js
@@ -3,7 +3,7 @@ import { URL } from '../../constants';
 const getRoutes = () => [
   {
     loader: () => import('./components/network-overview-page'),
-    path: URL.NETWORK_OVERVIEW,
+    path: URL.NETWORK_INSIGHTS,
   },
 ];
 

--- a/src/features/stats/components/protocol-fees-widget.js
+++ b/src/features/stats/components/protocol-fees-widget.js
@@ -9,11 +9,11 @@ import StatWidget from '../../../components/stat-widget';
 
 const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
 
-const FillVolumeWidget = ({ className, fillVolume, period }) => (
-  <StatWidget className={className} period={period} title="Fill Volume">
-    {_.isNumber(fillVolume) ? (
+const ProtocolFeesWidget = ({ accumulatedFees, className, period }) => (
+  <StatWidget className={className} period={period} title="Protocol Fees">
+    {_.isNumber(accumulatedFees) ? (
       <LocalisedAmount
-        amount={fillVolume}
+        amount={accumulatedFees}
         loadingIndicator={loadingIndicator}
       />
     ) : (
@@ -22,16 +22,16 @@ const FillVolumeWidget = ({ className, fillVolume, period }) => (
   </StatWidget>
 );
 
-FillVolumeWidget.propTypes = {
+ProtocolFeesWidget.propTypes = {
+  accumulatedFees: PropTypes.number,
   className: PropTypes.string,
-  fillVolume: PropTypes.number,
   period: sharedPropTypes.timePeriod,
 };
 
-FillVolumeWidget.defaultProps = {
+ProtocolFeesWidget.defaultProps = {
+  accumulatedFees: undefined,
   className: undefined,
-  fillVolume: undefined,
   period: undefined,
 };
 
-export default FillVolumeWidget;
+export default ProtocolFeesWidget;


### PR DESCRIPTION
This PR makes a number of improvements to the network overview page:

* Introduces a mobile time period filter
* Begins phasing out fill volume to avoid confusion
* Introduces an accumulated protocol fees widget
* Renames the page to "Network Insights"