### PR TITLE
Use standard anchors instead of react-router links

### DIFF
--- a/src/components/__snapshots__/app-layout.test.js.snap
+++ b/src/components/__snapshots__/app-layout.test.js.snap
@@ -11,7 +11,7 @@ exports[`app layout component should render with children 1`] = `
       class="container__StyledContainer-cj53s7-0 eMKfDZ header___StyledContainer-gflnft-4 jZVKWY container-fluid"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX"
         href="/"
       >
         <img
@@ -50,21 +50,21 @@ exports[`app layout component should render with children 1`] = `
         </div>
         <a
           aria-current="false"
-          class="link__InternalLink-sc-1m1n17q-1 kIJfjy navigation-link__StyledNavigationLink-do5zl-0 zWJCW"
+          class="link__StyledLink-sc-1m1n17q-0 gaobOX navigation-link__StyledNavigationLink-do5zl-0 zWJCW"
           href="/tokens"
         >
           Tokens
         </a>
         <a
           aria-current="false"
-          class="link__InternalLink-sc-1m1n17q-1 kIJfjy navigation-link__StyledNavigationLink-do5zl-0 zWJCW"
+          class="link__StyledLink-sc-1m1n17q-0 gaobOX navigation-link__StyledNavigationLink-do5zl-0 zWJCW"
           href="/relayers"
         >
           Relayers
         </a>
         <a
           aria-current="false"
-          class="link__InternalLink-sc-1m1n17q-1 kIJfjy navigation-link__StyledNavigationLink-do5zl-0 zWJCW"
+          class="link__StyledLink-sc-1m1n17q-0 gaobOX navigation-link__StyledNavigationLink-do5zl-0 zWJCW"
           href="/news-and-updates"
         >
           News & Updates
@@ -168,7 +168,7 @@ exports[`app layout component should render with children 1`] = `
             class="footer___StyledNav-htpw4v-6 dxYThI"
           >
             <a
-              class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__SocialLink-htpw4v-4 keHGOo"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__SocialLink-htpw4v-4 keHGOo"
               href="https://twitter.com/0xTracker"
               rel="noreferrer noopener"
               target="_blank"
@@ -190,7 +190,7 @@ exports[`app layout component should render with children 1`] = `
               </svg>
             </a>
             <a
-              class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__SocialLink-htpw4v-4 keHGOo"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__SocialLink-htpw4v-4 keHGOo"
               href="https://discord.gg/tnV8hud"
               rel="noreferrer noopener"
               target="_blank"
@@ -223,7 +223,7 @@ exports[`app layout component should render with children 1`] = `
           </h2>
           <nav>
             <a
-              class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
               href="https://docs.0xtracker.com/"
               rel="noreferrer noopener"
               target="_blank"
@@ -231,7 +231,7 @@ exports[`app layout component should render with children 1`] = `
               Overview
             </a>
             <a
-              class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
               href="https://docs.0xtracker.com/faqs"
               rel="noreferrer noopener"
               target="_blank"
@@ -239,7 +239,7 @@ exports[`app layout component should render with children 1`] = `
               FAQs
             </a>
             <a
-              class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
               href="https://medium.com/0x-tracker"
               rel="noreferrer noopener"
               target="_blank"
@@ -247,7 +247,7 @@ exports[`app layout component should render with children 1`] = `
               Blog
             </a>
             <a
-              class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
               href="https://docs.0xtracker.com/#need-to-get-in-touch"
               rel="noreferrer noopener"
               target="_blank"
@@ -266,7 +266,7 @@ exports[`app layout component should render with children 1`] = `
           </h2>
           <nav>
             <a
-              class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
               href="https://docs.0xtracker.com/api-reference/introduction"
               rel="noreferrer noopener"
               target="_blank"
@@ -274,7 +274,7 @@ exports[`app layout component should render with children 1`] = `
               API
             </a>
             <a
-              class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
               href="https://docs.0xtracker.com/contributing"
               rel="noreferrer noopener"
               target="_blank"
@@ -282,7 +282,7 @@ exports[`app layout component should render with children 1`] = `
               Contributing
             </a>
             <a
-              class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
               href="https://github.com/0xtracker"
               rel="noreferrer noopener"
               target="_blank"
@@ -301,13 +301,13 @@ exports[`app layout component should render with children 1`] = `
           </h2>
           <nav>
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy footer__NavLink-htpw4v-3 eijGhq"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
               href="/privacy"
             >
               Privacy Policy
             </a>
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy footer__NavLink-htpw4v-3 eijGhq"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
               href="/terms"
             >
               Terms Of Use

--- a/src/components/__snapshots__/footer.test.js.snap
+++ b/src/components/__snapshots__/footer.test.js.snap
@@ -27,7 +27,7 @@ exports[`should render without props 1`] = `
           class="footer___StyledNav-htpw4v-6 dxYThI"
         >
           <a
-            class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__SocialLink-htpw4v-4 keHGOo"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__SocialLink-htpw4v-4 keHGOo"
             href="https://twitter.com/0xTracker"
             rel="noreferrer noopener"
             target="_blank"
@@ -49,7 +49,7 @@ exports[`should render without props 1`] = `
             </svg>
           </a>
           <a
-            class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__SocialLink-htpw4v-4 keHGOo"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__SocialLink-htpw4v-4 keHGOo"
             href="https://discord.gg/tnV8hud"
             rel="noreferrer noopener"
             target="_blank"
@@ -82,7 +82,7 @@ exports[`should render without props 1`] = `
         </h2>
         <nav>
           <a
-            class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
             href="https://docs.0xtracker.com/"
             rel="noreferrer noopener"
             target="_blank"
@@ -90,7 +90,7 @@ exports[`should render without props 1`] = `
             Overview
           </a>
           <a
-            class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
             href="https://docs.0xtracker.com/faqs"
             rel="noreferrer noopener"
             target="_blank"
@@ -98,7 +98,7 @@ exports[`should render without props 1`] = `
             FAQs
           </a>
           <a
-            class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
             href="https://medium.com/0x-tracker"
             rel="noreferrer noopener"
             target="_blank"
@@ -106,7 +106,7 @@ exports[`should render without props 1`] = `
             Blog
           </a>
           <a
-            class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
             href="https://docs.0xtracker.com/#need-to-get-in-touch"
             rel="noreferrer noopener"
             target="_blank"
@@ -125,7 +125,7 @@ exports[`should render without props 1`] = `
         </h2>
         <nav>
           <a
-            class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
             href="https://docs.0xtracker.com/api-reference/introduction"
             rel="noreferrer noopener"
             target="_blank"
@@ -133,7 +133,7 @@ exports[`should render without props 1`] = `
             API
           </a>
           <a
-            class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
             href="https://docs.0xtracker.com/contributing"
             rel="noreferrer noopener"
             target="_blank"
@@ -141,7 +141,7 @@ exports[`should render without props 1`] = `
             Contributing
           </a>
           <a
-            class="link__OutboundLink-sc-1m1n17q-0 dFkevI footer__NavLink-htpw4v-3 eijGhq"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
             href="https://github.com/0xtracker"
             rel="noreferrer noopener"
             target="_blank"
@@ -160,13 +160,13 @@ exports[`should render without props 1`] = `
         </h2>
         <nav>
           <a
-            class="link__InternalLink-sc-1m1n17q-1 kIJfjy footer__NavLink-htpw4v-3 eijGhq"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
             href="/privacy"
           >
             Privacy Policy
           </a>
           <a
-            class="link__InternalLink-sc-1m1n17q-1 kIJfjy footer__NavLink-htpw4v-3 eijGhq"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX footer__NavLink-htpw4v-3 eijGhq"
             href="/terms"
           >
             Terms Of Use

--- a/src/components/__snapshots__/page-not-found.test.js.snap
+++ b/src/components/__snapshots__/page-not-found.test.js.snap
@@ -24,14 +24,14 @@ exports[`page not found component should render without props 1`] = `
           Oops, the page you requested doesn‘t exist.
         </p>
         <a
-          class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+          class="link__StyledLink-sc-1m1n17q-0 gaobOX"
           href="/"
         >
           Back to Dashboard
         </a>
       </div>
       <a
-        class="link__OutboundLink-sc-1m1n17q-0 dFkevI error-message__GhostLink-sc-1wau1ja-2 ldtSSD"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX error-message__GhostLink-sc-1wau1ja-2 ldtSSD"
         href="https://react-kawaii.now.sh/"
         rel="noreferrer noopener"
         target="_blank"

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -1,11 +1,10 @@
-import { Link as ReactRouterLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 import { colors } from '../styles/constants';
 
-const linkStyles = css`
+const StyledLink = styled.a`
   color: ${colors.indigo};
   cursor: pointer;
 
@@ -15,37 +14,26 @@ const linkStyles = css`
   }
 `;
 
-const OutboundLink = styled.a`
-  ${linkStyles}
-`;
-
-const InternalLink = styled(({ active, ...otherProps }) => (
-  <ReactRouterLink {...otherProps} />
-))`
-  ${linkStyles}
-`;
-
 const Link = ({ children, href, ...otherProps }) => {
   const isExternal = href.startsWith('http://') || href.startsWith('https://');
 
   if (isExternal) {
     return (
-      <OutboundLink
-        eventLabel={href}
+      <StyledLink
         href={href}
         rel="noreferrer noopener"
         target="_blank"
         {...otherProps}
       >
         {children}
-      </OutboundLink>
+      </StyledLink>
     );
   }
 
   return (
-    <InternalLink to={href} {...otherProps}>
+    <StyledLink href={href} {...otherProps}>
       {children}
-    </InternalLink>
+    </StyledLink>
   );
 };
 

--- a/src/features/currencies/components/rates-provider.js
+++ b/src/features/currencies/components/rates-provider.js
@@ -1,34 +1,11 @@
-import axios from 'axios';
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
-import { BASE_CURRENCY, CURRENCIES } from '../constants';
 import RatesContext from '../contexts/rates-context';
+import useFetchRates from '../hooks/use-fetch-rates';
 
 const RatesProvider = ({ children }) => {
-  const [rates, setRates] = useState();
-  const [error, setError] = useState();
-
-  useEffect(() => {
-    const toSymbols = Object.values(CURRENCIES)
-      .map(currency => currency.symbol)
-      .join(',');
-
-    axios
-      .get(
-        `https://min-api.cryptocompare.com/data/pricemulti?fsyms=${BASE_CURRENCY}&tsyms=${toSymbols}`,
-      )
-      .then(response => {
-        setRates(response.data[BASE_CURRENCY]);
-      })
-      .catch(caughtError => {
-        setError(caughtError);
-      });
-  }, []);
-
-  if (error) {
-    throw error;
-  }
+  const rates = useFetchRates();
 
   return (
     <RatesContext.Provider value={rates}>{children}</RatesContext.Provider>

--- a/src/features/currencies/hooks/use-fetch-rates.js
+++ b/src/features/currencies/hooks/use-fetch-rates.js
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import axios, { CancelToken } from 'axios';
+
+import { API_CALL_TIMEOUT } from '../../../constants';
+import { BASE_CURRENCY, CURRENCIES } from '../constants';
+
+const useFetchRates = () => {
+  const [rates, setRates] = useState();
+  const [error, setError] = useState();
+  const [cancelRequest, setCancelRequest] = useState();
+
+  useEffect(() => {
+    const source = CancelToken.source();
+
+    const toSymbols = Object.values(CURRENCIES)
+      .map(currency => currency.symbol)
+      .join(',');
+
+    axios
+      .get(
+        `https://min-api.cryptocompare.com/data/pricemulti?fsyms=${BASE_CURRENCY}&tsyms=${toSymbols}`,
+        {
+          cancelToken: source.token,
+          timeout: API_CALL_TIMEOUT,
+        },
+      )
+      .then(response => {
+        setRates(response.data[BASE_CURRENCY]);
+      })
+      .catch(caughtError => {
+        if (
+          axios.isCancel(caughtError) ||
+          caughtError.message === 'Request aborted'
+        ) {
+          // Ignore cancellation errors because they're deliberate
+        } else {
+          // Stash the error so that it can be rethrown in render scope
+          setError(caughtError);
+        }
+      });
+
+    setCancelRequest(source.cancel);
+
+    return () => cancelRequest();
+  }, []);
+
+  if (error) {
+    throw error;
+  }
+
+  return rates;
+};
+
+export default useFetchRates;

--- a/src/features/fills/components/__snapshots__/asset-label.test.js.snap
+++ b/src/features/fills/components/__snapshots__/asset-label.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`asset label component should render for ERC-20 asset 1`] = `
 <a
-  class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+  class="link__StyledLink-sc-1m1n17q-0 gaobOX"
   href="/tokens/0x12345"
 >
   Wrapped Ether
@@ -16,7 +16,7 @@ exports[`asset label component should render for ERC-20 asset 1`] = `
 
 exports[`asset label component should render for ERC-721 asset 1`] = `
 <a
-  class="link__OutboundLink-sc-1m1n17q-0 dFkevI"
+  class="link__StyledLink-sc-1m1n17q-0 gaobOX"
   href="https://opensea.io/assets/0x12345/999"
   rel="noreferrer noopener"
   target="_blank"
@@ -34,7 +34,7 @@ exports[`asset label component should render for ERC-721 asset 1`] = `
 
 exports[`asset label component should render for unknown token 1`] = `
 <a
-  class="link__OutboundLink-sc-1m1n17q-0 dFkevI"
+  class="link__StyledLink-sc-1m1n17q-0 gaobOX"
   href="https://opensea.io/assets/0x12345/999"
   rel="noreferrer noopener"
   target="_blank"

--- a/src/features/fills/components/__snapshots__/fill-details.test.js.snap
+++ b/src/features/fills/components/__snapshots__/fill-details.test.js.snap
@@ -14,7 +14,7 @@ exports[`fillDetails component should render V2 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__OutboundLink-sc-1m1n17q-0 dFkevI"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX"
         href="https://etherscan.io/tx/0x68e018d2c97cf76af6bae65297e6f5b6bc9680b95b828bdea5eb03a0b36ebc77"
         rel="noreferrer noopener"
         target="_blank"
@@ -31,7 +31,7 @@ exports[`fillDetails component should render V2 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX"
         href="/search?q=0x8104d4c4a32da7f1df357779fe6b8fc11dc6f4287de54566fe22eb35a74b0c71"
       >
         0x8104d4c4a32da7f1df357779fe6b8fc11dc6f4287de54566fe22eb35a74b0c71
@@ -46,7 +46,7 @@ exports[`fillDetails component should render V2 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX"
         href="/search?q=0x0dc411b17d337af85d83ea5a3577d09132aae866"
       >
         0x0dc411b17d337af85d83ea5a3577d09132aae866
@@ -71,7 +71,7 @@ exports[`fillDetails component should render V2 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy fill-relayer-link___StyledRelayerLink-sc-10d6xh4-0 eWOAxu"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX fill-relayer-link___StyledRelayerLink-sc-10d6xh4-0 eWOAxu"
         href="/relayers/radar-relay"
       >
         <img
@@ -126,7 +126,7 @@ exports[`fillDetails component should render V2 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX"
         href="/traders/0x2cfb4faaece38d5d03ef1ec9dfdf34964d6ab1b3"
       >
         0x2cfb4faaece38d5d03ef1ec9dfdf34964d6ab1b3
@@ -141,7 +141,7 @@ exports[`fillDetails component should render V2 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX"
         href="/traders/0x0dc411b17d337af85d83ea5a3577d09132aae866"
       >
         0x0dc411b17d337af85d83ea5a3577d09132aae866
@@ -180,7 +180,7 @@ exports[`fillDetails component should render V2 fill 1`] = `
           <span>
             0.96955 
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX"
               href="/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
             >
               Wrapped Ether  (WETH)
@@ -228,7 +228,7 @@ exports[`fillDetails component should render V2 fill 1`] = `
           <span>
             5,000 
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX"
               href="/tokens/0x4946fcea7c692606e8908002e55a582af44ac121"
             >
               FOAM Token  (FOAM)
@@ -275,7 +275,7 @@ exports[`fillDetails component should render V2 fill 1`] = `
           </svg>
           <span>
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX"
               href="/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
             >
               Wrapped Ether  (WETH)
@@ -310,7 +310,7 @@ exports[`fillDetails component should render V2 fill 1`] = `
           </svg>
           <span>
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX"
               href="/tokens/0x4946fcea7c692606e8908002e55a582af44ac121"
             >
               FOAM Token  (FOAM)
@@ -355,7 +355,7 @@ exports[`fillDetails component should render V2 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX"
         href="/search?q=0xa258b39954cef5cb142fd567a46cddb31a670124"
       >
         0xa258b39954cef5cb142fd567a46cddb31a670124
@@ -379,7 +379,7 @@ exports[`fillDetails component should render V3 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__OutboundLink-sc-1m1n17q-0 dFkevI"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX"
         href="https://etherscan.io/tx/0x68e018d2c97cf76af6bae65297e6f5b6bc9680b95b828bdea5eb03a0b36ebc77"
         rel="noreferrer noopener"
         target="_blank"
@@ -396,7 +396,7 @@ exports[`fillDetails component should render V3 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX"
         href="/search?q=0x8104d4c4a32da7f1df357779fe6b8fc11dc6f4287de54566fe22eb35a74b0c71"
       >
         0x8104d4c4a32da7f1df357779fe6b8fc11dc6f4287de54566fe22eb35a74b0c71
@@ -411,7 +411,7 @@ exports[`fillDetails component should render V3 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX"
         href="/search?q=0x0dc411b17d337af85d83ea5a3577d09132aae866"
       >
         0x0dc411b17d337af85d83ea5a3577d09132aae866
@@ -436,7 +436,7 @@ exports[`fillDetails component should render V3 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy fill-relayer-link___StyledRelayerLink-sc-10d6xh4-0 eWOAxu"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX fill-relayer-link___StyledRelayerLink-sc-10d6xh4-0 eWOAxu"
         href="/relayers/radar-relay"
       >
         <img
@@ -491,7 +491,7 @@ exports[`fillDetails component should render V3 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX"
         href="/traders/0x2cfb4faaece38d5d03ef1ec9dfdf34964d6ab1b3"
       >
         0x2cfb4faaece38d5d03ef1ec9dfdf34964d6ab1b3
@@ -506,7 +506,7 @@ exports[`fillDetails component should render V3 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX"
         href="/traders/0x0dc411b17d337af85d83ea5a3577d09132aae866"
       >
         0x0dc411b17d337af85d83ea5a3577d09132aae866
@@ -545,7 +545,7 @@ exports[`fillDetails component should render V3 fill 1`] = `
           <span>
             0.96955 
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX"
               href="/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
             >
               Wrapped Ether  (WETH)
@@ -593,7 +593,7 @@ exports[`fillDetails component should render V3 fill 1`] = `
           <span>
             5,000 
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX"
               href="/tokens/0x4946fcea7c692606e8908002e55a582af44ac121"
             >
               FOAM Token  (FOAM)
@@ -640,7 +640,7 @@ exports[`fillDetails component should render V3 fill 1`] = `
           </svg>
           <span>
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX"
               href="/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
             >
               Wrapped Ether  (WETH)
@@ -675,7 +675,7 @@ exports[`fillDetails component should render V3 fill 1`] = `
           </svg>
           <span>
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX"
               href="/tokens/0x4946fcea7c692606e8908002e55a582af44ac121"
             >
               FOAM Token  (FOAM)
@@ -700,7 +700,7 @@ exports[`fillDetails component should render V3 fill 1`] = `
       class="fill-detail__Value-q3it9r-1 hhYdhc"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX"
         href="/search?q=0xa258b39954cef5cb142fd567a46cddb31a670124"
       >
         0xa258b39954cef5cb142fd567a46cddb31a670124

--- a/src/features/fills/components/__snapshots__/fill-list-assets.test.js.snap
+++ b/src/features/fills/components/__snapshots__/fill-list-assets.test.js.snap
@@ -5,7 +5,7 @@ exports[`fill list assets component should link ERC-20 asset 1`] = `
   150
    
   <a
-    class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+    class="link__StyledLink-sc-1m1n17q-0 gaobOX"
     href="/tokens/0x12345"
   >
     WETH
@@ -16,7 +16,7 @@ exports[`fill list assets component should link ERC-20 asset 1`] = `
 exports[`fill list assets component should link ERC-721 asset 1`] = `
 <div>
   <a
-    class="link__OutboundLink-sc-1m1n17q-0 dFkevI"
+    class="link__StyledLink-sc-1m1n17q-0 gaobOX"
     href="https://opensea.io/assets/0x12345/999"
     rel="noreferrer noopener"
     target="_blank"

--- a/src/features/fills/components/__snapshots__/fill-relayer-link.test.js.snap
+++ b/src/features/fills/components/__snapshots__/fill-relayer-link.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`returns "None" when the trade does not have a fee recipient 1`] = `
 <a
-  class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+  class="link__StyledLink-sc-1m1n17q-0 gaobOX"
   href="/relayers/unknown"
 >
   Unknown
@@ -11,7 +11,7 @@ exports[`returns "None" when the trade does not have a fee recipient 1`] = `
 
 exports[`returns a fee recipient link when the trade does not have a relayer but does have a fee recipient 1`] = `
 <a
-  class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+  class="link__StyledLink-sc-1m1n17q-0 gaobOX"
   href="/relayers/unknown"
 >
   Unknown
@@ -20,7 +20,7 @@ exports[`returns a fee recipient link when the trade does not have a relayer but
 
 exports[`returns relayer link when trade has a relayer 1`] = `
 <a
-  class="link__InternalLink-sc-1m1n17q-1 kIJfjy fill-relayer-link___StyledRelayerLink-sc-10d6xh4-0 eWOAxu"
+  class="link__StyledLink-sc-1m1n17q-0 gaobOX fill-relayer-link___StyledRelayerLink-sc-10d6xh4-0 eWOAxu"
   href="/relayers/google"
 >
   Google

--- a/src/features/fills/components/__snapshots__/recent-fills-list.test.js.snap
+++ b/src/features/fills/components/__snapshots__/recent-fills-list.test.js.snap
@@ -9,7 +9,7 @@ exports[`should render an assortment of fills 1`] = `
       class="recent-fills-item__StyledRecentFillsItem-sc-1yc2z6o-0 gZyfwm"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy recent-fills-item-image___StyledRelayerLink-hf0nj8-0 hheJGA"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX recent-fills-item-image___StyledRelayerLink-hf0nj8-0 hheJGA"
         href="/relayers/token-trove"
       >
         <img
@@ -25,7 +25,7 @@ exports[`should render an assortment of fills 1`] = `
           class="recent-fills-item__Heading-sc-1yc2z6o-2 cfJjoe"
         >
           <a
-            class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX"
             href="/fills/5dd96f9d250aa512ae416656"
           >
             CARD #41011762 ⇋ 0.19 WETH
@@ -39,7 +39,7 @@ exports[`should render an assortment of fills 1`] = `
           </dt>
           <dd>
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy recent-fills-item__SourceLink-sc-1yc2z6o-4 exkLNx"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX recent-fills-item__SourceLink-sc-1yc2z6o-4 exkLNx"
               href="/relayers/token-trove"
             >
               TokenTrove
@@ -63,7 +63,7 @@ exports[`should render an assortment of fills 1`] = `
       class="recent-fills-item__StyledRecentFillsItem-sc-1yc2z6o-0 gZyfwm"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy recent-fills-item-image___StyledRelayerLink-hf0nj8-0 hheJGA"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX recent-fills-item-image___StyledRelayerLink-hf0nj8-0 hheJGA"
         href="/relayers/token-trove"
       >
         <img
@@ -79,7 +79,7 @@ exports[`should render an assortment of fills 1`] = `
           class="recent-fills-item__Heading-sc-1yc2z6o-2 cfJjoe"
         >
           <a
-            class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX"
             href="/fills/5dd96f6d250aa512ae40bad3"
           >
             Unknown #122150411 ⇋ 0.975 WETH
@@ -93,7 +93,7 @@ exports[`should render an assortment of fills 1`] = `
           </dt>
           <dd>
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy recent-fills-item__SourceLink-sc-1yc2z6o-4 exkLNx"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX recent-fills-item__SourceLink-sc-1yc2z6o-4 exkLNx"
               href="/relayers/token-trove"
             >
               TokenTrove
@@ -117,7 +117,7 @@ exports[`should render an assortment of fills 1`] = `
       class="recent-fills-item__StyledRecentFillsItem-sc-1yc2z6o-0 gZyfwm"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy recent-fills-item-image___StyledRelayerLink-hf0nj8-0 hheJGA"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX recent-fills-item-image___StyledRelayerLink-hf0nj8-0 hheJGA"
         href="/relayers/star-bit"
       >
         <img
@@ -133,7 +133,7 @@ exports[`should render an assortment of fills 1`] = `
           class="recent-fills-item__Heading-sc-1yc2z6o-2 cfJjoe"
         >
           <a
-            class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX"
             href="/fills/5dd96f3f250aa512ae3fb34a"
           >
             0.0403 WETH ⇋ 2,693 SBT
@@ -147,7 +147,7 @@ exports[`should render an assortment of fills 1`] = `
           </dt>
           <dd>
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy recent-fills-item__SourceLink-sc-1yc2z6o-4 exkLNx"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX recent-fills-item__SourceLink-sc-1yc2z6o-4 exkLNx"
               href="/relayers/star-bit"
             >
               STAR BIT
@@ -171,7 +171,7 @@ exports[`should render an assortment of fills 1`] = `
       class="recent-fills-item__StyledRecentFillsItem-sc-1yc2z6o-0 gZyfwm"
     >
       <a
-        class="link__InternalLink-sc-1m1n17q-1 kIJfjy recent-fills-item-image___StyledRelayerLink-hf0nj8-0 hheJGA"
+        class="link__StyledLink-sc-1m1n17q-0 gaobOX recent-fills-item-image___StyledRelayerLink-hf0nj8-0 hheJGA"
         href="/relayers/star-bit"
       >
         <img
@@ -187,7 +187,7 @@ exports[`should render an assortment of fills 1`] = `
           class="recent-fills-item__Heading-sc-1yc2z6o-2 cfJjoe"
         >
           <a
-            class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+            class="link__StyledLink-sc-1m1n17q-0 gaobOX"
             href="/fills/5dd96f3f250aa512ae3fb34d"
           >
             2,693 SBT ⇋ Unknown
@@ -201,7 +201,7 @@ exports[`should render an assortment of fills 1`] = `
           </dt>
           <dd>
             <a
-              class="link__InternalLink-sc-1m1n17q-1 kIJfjy recent-fills-item__SourceLink-sc-1yc2z6o-4 exkLNx"
+              class="link__StyledLink-sc-1m1n17q-0 gaobOX recent-fills-item__SourceLink-sc-1yc2z6o-4 exkLNx"
               href="/relayers/star-bit"
             >
               STAR BIT

--- a/src/features/relayers/components/__snapshots__/relayer-list.test.js.snap
+++ b/src/features/relayers/components/__snapshots__/relayer-list.test.js.snap
@@ -42,7 +42,7 @@ exports[`renders with basic props 1`] = `
         class="align-middle"
       >
         <a
-          class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+          class="link__StyledLink-sc-1m1n17q-0 gaobOX"
           href="/relayers/ddex"
         >
           <svg
@@ -68,14 +68,14 @@ exports[`renders with basic props 1`] = `
         width="99%"
       >
         <a
-          class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+          class="link__StyledLink-sc-1m1n17q-0 gaobOX"
           href="/relayers/ddex"
         >
           DDEX
         </a>
         <br />
         <a
-          class="link__OutboundLink-sc-1m1n17q-0 dFkevI relayer-list___StyledLink-sc-1herowu-0 gnBtj"
+          class="link__StyledLink-sc-1m1n17q-0 gaobOX relayer-list___StyledLink-sc-1herowu-0 gnBtj"
           href="https://ddex.io"
           rel="noreferrer noopener"
           target="_blank"
@@ -107,7 +107,7 @@ exports[`renders with basic props 1`] = `
         class="align-middle"
       >
         <a
-          class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+          class="link__StyledLink-sc-1m1n17q-0 gaobOX"
           href="/relayers/paradex"
         >
           <svg
@@ -133,14 +133,14 @@ exports[`renders with basic props 1`] = `
         width="99%"
       >
         <a
-          class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+          class="link__StyledLink-sc-1m1n17q-0 gaobOX"
           href="/relayers/paradex"
         >
           Paradex
         </a>
         <br />
         <a
-          class="link__OutboundLink-sc-1m1n17q-0 dFkevI relayer-list___StyledLink-sc-1herowu-0 gnBtj"
+          class="link__StyledLink-sc-1m1n17q-0 gaobOX relayer-list___StyledLink-sc-1herowu-0 gnBtj"
           href="https://paradex.io"
           rel="noreferrer noopener"
           target="_blank"
@@ -172,7 +172,7 @@ exports[`renders with basic props 1`] = `
         class="align-middle"
       >
         <a
-          class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+          class="link__StyledLink-sc-1m1n17q-0 gaobOX"
           href="/relayers/radar-relay"
         >
           <svg
@@ -198,14 +198,14 @@ exports[`renders with basic props 1`] = `
         width="99%"
       >
         <a
-          class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+          class="link__StyledLink-sc-1m1n17q-0 gaobOX"
           href="/relayers/radar-relay"
         >
           Radar Relay
         </a>
         <br />
         <a
-          class="link__OutboundLink-sc-1m1n17q-0 dFkevI relayer-list___StyledLink-sc-1herowu-0 gnBtj"
+          class="link__StyledLink-sc-1m1n17q-0 gaobOX relayer-list___StyledLink-sc-1herowu-0 gnBtj"
           href="https://radarrelay.com"
           rel="noreferrer noopener"
           target="_blank"

--- a/src/features/traders/components/__snapshots__/trader-link.test.js.snap
+++ b/src/features/traders/components/__snapshots__/trader-link.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`should render a trader link 1`] = `
 <a
-  class="link__InternalLink-sc-1m1n17q-1 kIJfjy"
+  class="link__StyledLink-sc-1m1n17q-0 gaobOX"
   href="/traders/0xb14232b0204b2f7bb6ba5aff59ef36030f7fe38b"
 >
   Hello World

--- a/src/hooks/use-api.js
+++ b/src/hooks/use-api.js
@@ -56,7 +56,7 @@ const useApi = (method, options = {}) => {
       }));
 
       fetchData().catch(error => {
-        if (axios.isCancel(error)) {
+        if (axios.isCancel(error) || error.message === 'Request aborted') {
           // Ignore cancellation errors because they're deliberate
         } else {
           // Stash the error so that it can be rethrown in render scope


### PR DESCRIPTION
This PR replaces react-router links with standard anchors. The goal here is to collect better usage analytics since Netlify Analytics collects metrics using server-side page requests.