### PR TITLE
Add asset bridges page

### DIFF
--- a/src/components/routes.js
+++ b/src/components/routes.js
@@ -3,6 +3,7 @@ import { Switch } from 'react-router-dom';
 import React from 'react';
 
 import createPageRoute from '../util/create-page-route';
+import getAssetBridgesRoutes from '../features/asset-bridges/get-routes';
 import getContentRoutes from '../features/content/get-routes';
 import getFillsRoutes from '../features/fills/get-routes';
 import getHomeRoutes from '../features/home/get-home-routes';
@@ -23,6 +24,7 @@ const routes = _.flatten([
   getSearchRoutes(),
   getTokensRoutes(),
   getTradersRoutes(),
+  getAssetBridgesRoutes(),
   { key: '404', loader: () => import('./page-not-found') },
 ]);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -35,6 +35,7 @@ const DATE_FORMAT = {
 const GENESIS_DATE = new Date('2017-08-15T00:00:00Z');
 
 const URL = {
+  ASSET_BRIDGES: '/asset-bridges',
   FILL: '/fills/:id',
   FILLS: '/fills',
   HOME: '/',

--- a/src/features/asset-bridges/components/active-bridges-widget.js
+++ b/src/features/asset-bridges/components/active-bridges-widget.js
@@ -1,0 +1,29 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { summarizeNumber } from '../../../util';
+import LoadingIndicator from '../../../components/loading-indicator';
+import StatWidget from '../../../components/stat-widget';
+
+const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
+
+const ActiveBridgesWidget = ({ bridgeCount, ...otherProps }) => (
+  <StatWidget
+    title="Active Bridges"
+    tooltip="The total number of asset bridges which were active in the selected period."
+    {...otherProps}
+  >
+    {_.isNumber(bridgeCount) ? summarizeNumber(bridgeCount) : loadingIndicator}
+  </StatWidget>
+);
+
+ActiveBridgesWidget.propTypes = {
+  bridgeCount: PropTypes.number,
+};
+
+ActiveBridgesWidget.defaultProps = {
+  bridgeCount: undefined,
+};
+
+export default ActiveBridgesWidget;

--- a/src/features/asset-bridges/components/active-bridges-widget.js
+++ b/src/features/asset-bridges/components/active-bridges-widget.js
@@ -11,7 +11,7 @@ const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
 const ActiveBridgesWidget = ({ bridgeCount, ...otherProps }) => (
   <StatWidget
     title="Active Bridges"
-    tooltip="The total number of asset bridges which were active in the selected period."
+    tooltip="The total number of asset bridges which were used in the selected period."
     {...otherProps}
   >
     {_.isNumber(bridgeCount) ? summarizeNumber(bridgeCount) : loadingIndicator}

--- a/src/features/asset-bridges/components/asset-bridge-image.js
+++ b/src/features/asset-bridges/components/asset-bridge-image.js
@@ -1,0 +1,66 @@
+import _ from 'lodash';
+import { SwapBox } from 'styled-icons/remix-fill';
+import { UserSecret } from 'styled-icons/fa-solid';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { colors } from '../../../styles/constants';
+
+const AssetBridgeImage = ({
+  className,
+  height,
+  imageUrl,
+  isPrivate,
+  width,
+}) => {
+  if (_.isString(imageUrl)) {
+    return (
+      <img
+        className={className}
+        css={`
+          border-radius: 0.25rem;
+          height: ${height}px;
+          width: ${width}px;
+        `}
+        src={imageUrl}
+      />
+    );
+  }
+
+  if (isPrivate) {
+    return (
+      <UserSecret
+        className={className}
+        color={colors.mystic}
+        height={height}
+        width={width}
+      />
+    );
+  }
+
+  return (
+    <SwapBox
+      className={className}
+      color={colors.mystic}
+      height={height}
+      width={width}
+    />
+  );
+};
+
+AssetBridgeImage.propTypes = {
+  className: PropTypes.string,
+  height: PropTypes.number,
+  imageUrl: PropTypes.string.isRequired,
+  isPrivate: PropTypes.bool,
+  width: PropTypes.number,
+};
+
+AssetBridgeImage.defaultProps = {
+  className: undefined,
+  height: 40,
+  isPrivate: false,
+  width: 40,
+};
+
+export default AssetBridgeImage;

--- a/src/features/asset-bridges/components/asset-bridge-list.js
+++ b/src/features/asset-bridges/components/asset-bridge-list.js
@@ -1,0 +1,83 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import AssetBridgeImage from './asset-bridge-image';
+import HelpWidget from '../../../components/help-widget';
+import LocalisedAmount from '../../currencies/components/localised-amount';
+import MiniRelayerMetrics from '../../metrics/components/mini-relayer-metrics';
+import Number from '../../../components/number';
+import SubTitle from '../../../components/sub-title';
+
+const AssetBridgeList = ({ assetBridges, positionOffset, statsPeriod }) => (
+  <table className="table table-responsive">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th colSpan="2">Bridge</th>
+        <th className="text-right">
+          Trades
+          <HelpWidget css="margin-left: 0.25rem;">
+            The number of unique trades for a given relayer in the selected
+            period.
+          </HelpWidget>
+        </th>
+        <th className="text-right">
+          Volume
+          <HelpWidget css="margin-left: 0.25rem;">
+            The total value of all trades for a given relayer in the selected
+            period.
+          </HelpWidget>
+        </th>
+        <th className="text-right">
+          Volume Trend
+          <HelpWidget css="margin-left: 0.25rem;">
+            The trend of trading volume for a given relayer in the selected
+            period.
+          </HelpWidget>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      {assetBridges.map((bridge, index) => (
+        <tr key={bridge.address}>
+          <td className="align-middle">{`${positionOffset + index + 1}`}</td>
+          <td className="align-middle">
+            <AssetBridgeImage
+              imageUrl={bridge.imageUrl}
+              isPrivate={
+                _.isString(bridge.name) && bridge.name.startsWith('Private')
+              }
+            />
+          </td>
+          <td className="align-middle" width="99%">
+            {_.isString(bridge.name) ? bridge.name : 'Unknown Bridge'}
+            <SubTitle>{bridge.address}</SubTitle>
+          </td>
+          <td className="align-middle text-right">
+            <Number summarize>{bridge.stats.tradeCount}</Number>
+          </td>
+          <td className="align-middle text-right">
+            <LocalisedAmount amount={bridge.stats.tradeVolume} summarize />
+          </td>
+          <td>
+            <MiniRelayerMetrics
+              height={40}
+              period={statsPeriod}
+              relayerId="radarRelay"
+              width={120}
+            />
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+AssetBridgeList.propTypes = {
+  assetBridges: PropTypes.array.isRequired,
+  positionOffset: PropTypes.number.isRequired,
+  statsPeriod: PropTypes.string.isRequired,
+};
+
+export default AssetBridgeList;

--- a/src/features/asset-bridges/components/asset-bridge-list.js
+++ b/src/features/asset-bridges/components/asset-bridge-list.js
@@ -18,21 +18,21 @@ const AssetBridgeList = ({ assetBridges, positionOffset, statsPeriod }) => (
         <th className="text-right">
           Trades
           <HelpWidget css="margin-left: 0.25rem;">
-            The number of unique trades for a given relayer in the selected
+            The number of trades which involved a given bridge in the selected
             period.
           </HelpWidget>
         </th>
         <th className="text-right">
           Volume
           <HelpWidget css="margin-left: 0.25rem;">
-            The total value of all trades for a given relayer in the selected
-            period.
+            The total volume of all trades which involved a given bridge in the
+            selected period.
           </HelpWidget>
         </th>
         <th className="text-right">
           Volume Trend
           <HelpWidget css="margin-left: 0.25rem;">
-            The trend of trading volume for a given relayer in the selected
+            The trend of trading volume for a given bridge in the selected
             period.
           </HelpWidget>
         </th>

--- a/src/features/asset-bridges/components/asset-bridge-list.js
+++ b/src/features/asset-bridges/components/asset-bridge-list.js
@@ -5,7 +5,7 @@ import React from 'react';
 import AssetBridgeImage from './asset-bridge-image';
 import HelpWidget from '../../../components/help-widget';
 import LocalisedAmount from '../../currencies/components/localised-amount';
-import MiniRelayerMetrics from '../../metrics/components/mini-relayer-metrics';
+import MiniBridgeMetrics from './mini-bridge-metrics';
 import Number from '../../../components/number';
 import SubTitle from '../../../components/sub-title';
 
@@ -61,10 +61,10 @@ const AssetBridgeList = ({ assetBridges, positionOffset, statsPeriod }) => (
             <LocalisedAmount amount={bridge.stats.tradeVolume} summarize />
           </td>
           <td>
-            <MiniRelayerMetrics
+            <MiniBridgeMetrics
+              bridgeAddress={bridge.address}
               height={40}
               period={statsPeriod}
-              relayerId="radarRelay"
               width={120}
             />
           </td>

--- a/src/features/asset-bridges/components/asset-bridges-page.js
+++ b/src/features/asset-bridges/components/asset-bridges-page.js
@@ -1,0 +1,162 @@
+import _ from 'lodash';
+import { Helmet } from 'react-helmet';
+import { useSearchParam } from 'react-use';
+import { useHistory } from 'react-router';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { TIME_PERIOD, URL } from '../../../constants';
+import { colors } from '../../../styles/constants';
+import AssetBridgeList from './asset-bridge-list';
+import AssetBridgingStats from './asset-bridging-stats';
+import buildUrl from '../../../util/build-url';
+import Card from '../../../components/card';
+import Hidden from '../../../components/hidden';
+import LoadingIndicator from '../../../components/loading-indicator';
+import NetworkMetrics from '../../metrics/components/network-metrics';
+import PageLayout from '../../../components/page-layout';
+import Paginator from '../../../components/paginator';
+import ResponsiveTimePeriodFilter from '../../../components/responsive-time-period-filter';
+import TabbedCard from '../../../components/tabbed-card';
+import useAssetBridges from '../hooks/use-asset-bridges';
+import withPagination from '../../../components/with-pagination';
+import useNetworkStats from '../../stats/hooks/use-network-stats';
+import HelpWidget from '../../../components/help-widget';
+
+const periodDescriptions = {
+  [TIME_PERIOD.DAY]: 'in the last 24 hours',
+  [TIME_PERIOD.WEEK]: 'in the last week',
+  [TIME_PERIOD.MONTH]: 'in the last month',
+  [TIME_PERIOD.YEAR]: 'in the last year',
+  [TIME_PERIOD.ALL]: 'from all time',
+};
+
+const getStats = (bridges, networkStats) => {
+  if (bridges === undefined) {
+    return {};
+  }
+
+  const tradeVolume = _.sumBy(bridges, 'stats.tradeVolume');
+
+  return {
+    bridgeCount: bridges.length,
+    tradeCount: _.sumBy(bridges, 'stats.tradeCount'),
+    tradeVolume,
+    volumeShare: _.isObject(networkStats)
+      ? (tradeVolume / networkStats.tradeVolume) * 100
+      : undefined,
+  };
+};
+
+const AssetBridgesPage = ({ page, setPage }) => {
+  const history = useHistory();
+  const statsPeriod = useSearchParam('statsPeriod') || TIME_PERIOD.MONTH;
+  const [networkStats] = useNetworkStats({ period: statsPeriod });
+
+  const [assetBridges, loadingAssetBridges] = useAssetBridges({
+    autoReload: true,
+    limit: 25,
+    page,
+    statsPeriod,
+  });
+
+  const { items, pageCount, pageSize, recordCount } = assetBridges;
+  const { bridgeCount, tradeCount, tradeVolume, volumeShare } = getStats(
+    items,
+    networkStats,
+  );
+
+  return (
+    <>
+      <Helmet key="relayers">
+        <title>Asset Bridges</title>
+      </Helmet>
+      <PageLayout
+        filter={
+          <ResponsiveTimePeriodFilter
+            name="statsPeriod"
+            onChange={(newPeriod) => {
+              history.push(
+                buildUrl(URL.ASSET_BRIDGES, { statsPeriod: newPeriod }),
+              );
+            }}
+            value={statsPeriod}
+          />
+        }
+        title={
+          <span>
+            <span css="display: flex; align-items: center;">
+              Asset Bridges{' '}
+              <HelpWidget css="margin-left: 0.5rem;">
+                Information describing what asset bridges are all about.
+              </HelpWidget>
+            </span>
+            <Hidden above="xs">
+              <small
+                css={`
+                  color: ${colors.stormGray};
+                  display: block;
+                  font-size: 0.9rem;
+                  text-transform: lowercase;
+                `}
+              >
+                {periodDescriptions[statsPeriod]}
+              </small>
+            </Hidden>
+          </span>
+        }
+      >
+        <AssetBridgingStats
+          bridgeCount={bridgeCount}
+          trades={tradeCount}
+          volume={tradeVolume}
+          volumeShare={volumeShare}
+        />
+        <TabbedCard
+          css="height: 330px; margin-bottom: 2rem;"
+          tabs={[
+            {
+              component: (
+                <NetworkMetrics period={statsPeriod} type="tradeVolume" />
+              ),
+              title: 'Bridged Volume',
+            },
+            {
+              component: (
+                <NetworkMetrics period={statsPeriod} type="tradeCount" />
+              ),
+              title: 'Bridged Trades',
+            },
+          ]}
+        />
+        <Card fullHeight>
+          {loadingAssetBridges ? (
+            <LoadingIndicator centered />
+          ) : (
+            <>
+              <AssetBridgeList
+                assetBridges={items}
+                positionOffset={(page - 1) * pageSize}
+                statsPeriod={statsPeriod}
+              />
+              <Paginator
+                onPageChange={setPage}
+                page={page}
+                pageCount={pageCount}
+                pageSize={pageSize}
+                recordCount={recordCount}
+              />
+            </>
+          )}
+        </Card>
+      </PageLayout>
+    </>
+  );
+};
+
+AssetBridgesPage.propTypes = {
+  page: PropTypes.number.isRequired,
+  setPage: PropTypes.func.isRequired,
+};
+
+export default withPagination(AssetBridgesPage);

--- a/src/features/asset-bridges/components/asset-bridges-page.js
+++ b/src/features/asset-bridges/components/asset-bridges-page.js
@@ -7,12 +7,12 @@ import React from 'react';
 import { TIME_PERIOD, URL } from '../../../constants';
 import { colors } from '../../../styles/constants';
 import AssetBridgeList from './asset-bridge-list';
+import AssetBridgingMetrics from './asset-bridging-metrics';
 import AssetBridgingStats from './asset-bridging-stats';
 import buildUrl from '../../../util/build-url';
 import Card from '../../../components/card';
 import Hidden from '../../../components/hidden';
 import LoadingIndicator from '../../../components/loading-indicator';
-import NetworkMetrics from '../../metrics/components/network-metrics';
 import PageLayout from '../../../components/page-layout';
 import Paginator from '../../../components/paginator';
 import ResponsiveTimePeriodFilter from '../../../components/responsive-time-period-filter';
@@ -64,7 +64,10 @@ const AssetBridgesPage = ({ page, setPage }) => {
             <span css="display: flex; align-items: center;">
               Asset Bridges{' '}
               <HelpWidget css="margin-left: 0.5rem;">
-                Information describing what asset bridges are all about.
+                Asset bridges allow 0x to tap into on-chain liquidity sources
+                like Kyber and Uniswap by sourcing maker liquidity from
+                contracts rather than wallets. This page provides an overview of
+                briding contract activity for a given period of time.
               </HelpWidget>
             </span>
             <Hidden above="xs">
@@ -88,13 +91,13 @@ const AssetBridgesPage = ({ page, setPage }) => {
           tabs={[
             {
               component: (
-                <NetworkMetrics period={statsPeriod} type="tradeVolume" />
+                <AssetBridgingMetrics period={statsPeriod} type="tradeVolume" />
               ),
               title: 'Bridged Volume',
             },
             {
               component: (
-                <NetworkMetrics period={statsPeriod} type="tradeCount" />
+                <AssetBridgingMetrics period={statsPeriod} type="tradeCount" />
               ),
               title: 'Bridged Trades',
             },

--- a/src/features/asset-bridges/components/asset-bridges-page.js
+++ b/src/features/asset-bridges/components/asset-bridges-page.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { Helmet } from 'react-helmet';
 import { useSearchParam } from 'react-use';
 import { useHistory } from 'react-router';
@@ -20,7 +19,6 @@ import ResponsiveTimePeriodFilter from '../../../components/responsive-time-peri
 import TabbedCard from '../../../components/tabbed-card';
 import useAssetBridges from '../hooks/use-asset-bridges';
 import withPagination from '../../../components/with-pagination';
-import useNetworkStats from '../../stats/hooks/use-network-stats';
 import HelpWidget from '../../../components/help-widget';
 
 const periodDescriptions = {
@@ -31,27 +29,9 @@ const periodDescriptions = {
   [TIME_PERIOD.ALL]: 'from all time',
 };
 
-const getStats = (bridges, networkStats) => {
-  if (bridges === undefined) {
-    return {};
-  }
-
-  const tradeVolume = _.sumBy(bridges, 'stats.tradeVolume');
-
-  return {
-    bridgeCount: bridges.length,
-    tradeCount: _.sumBy(bridges, 'stats.tradeCount'),
-    tradeVolume,
-    volumeShare: _.isObject(networkStats)
-      ? (tradeVolume / networkStats.tradeVolume) * 100
-      : undefined,
-  };
-};
-
 const AssetBridgesPage = ({ page, setPage }) => {
   const history = useHistory();
   const statsPeriod = useSearchParam('statsPeriod') || TIME_PERIOD.MONTH;
-  const [networkStats] = useNetworkStats({ period: statsPeriod });
 
   const [assetBridges, loadingAssetBridges] = useAssetBridges({
     autoReload: true,
@@ -61,10 +41,6 @@ const AssetBridgesPage = ({ page, setPage }) => {
   });
 
   const { items, pageCount, pageSize, recordCount } = assetBridges;
-  const { bridgeCount, tradeCount, tradeVolume, volumeShare } = getStats(
-    items,
-    networkStats,
-  );
 
   return (
     <>
@@ -106,12 +82,7 @@ const AssetBridgesPage = ({ page, setPage }) => {
           </span>
         }
       >
-        <AssetBridgingStats
-          bridgeCount={bridgeCount}
-          trades={tradeCount}
-          volume={tradeVolume}
-          volumeShare={volumeShare}
-        />
+        <AssetBridgingStats bridgeCount={recordCount} period={statsPeriod} />
         <TabbedCard
           css="height: 330px; margin-bottom: 2rem;"
           tabs={[

--- a/src/features/asset-bridges/components/asset-bridges-page.js
+++ b/src/features/asset-bridges/components/asset-bridges-page.js
@@ -6,6 +6,7 @@ import React from 'react';
 
 import { TIME_PERIOD, URL } from '../../../constants';
 import { colors } from '../../../styles/constants';
+import { media } from '../../../styles/util';
 import AssetBridgeList from './asset-bridge-list';
 import AssetBridgingMetrics from './asset-bridging-metrics';
 import AssetBridgingStats from './asset-bridging-stats';
@@ -22,11 +23,11 @@ import withPagination from '../../../components/with-pagination';
 import HelpWidget from '../../../components/help-widget';
 
 const periodDescriptions = {
-  [TIME_PERIOD.DAY]: 'in the last 24 hours',
-  [TIME_PERIOD.WEEK]: 'in the last week',
-  [TIME_PERIOD.MONTH]: 'in the last month',
-  [TIME_PERIOD.YEAR]: 'in the last year',
-  [TIME_PERIOD.ALL]: 'from all time',
+  [TIME_PERIOD.DAY]: 'active in the last 24h',
+  [TIME_PERIOD.WEEK]: 'active in the last 7d',
+  [TIME_PERIOD.MONTH]: 'active in the last 30d',
+  [TIME_PERIOD.YEAR]: 'active in the last 365d',
+  [TIME_PERIOD.ALL]: 'active since 0x launch',
 };
 
 const AssetBridgesPage = ({ page, setPage }) => {
@@ -87,7 +88,14 @@ const AssetBridgesPage = ({ page, setPage }) => {
       >
         <AssetBridgingStats bridgeCount={recordCount} period={statsPeriod} />
         <TabbedCard
-          css="height: 330px; margin-bottom: 2rem;"
+          css={`
+            height: 330px;
+            margin-bottom: 1.25rem;
+
+            ${media.greaterThan('lg')`
+              margin-bottom: 2rem;
+            `}
+          `}
           tabs={[
             {
               component: (

--- a/src/features/asset-bridges/components/asset-bridging-metrics-chart.js
+++ b/src/features/asset-bridges/components/asset-bridging-metrics-chart.js
@@ -1,0 +1,117 @@
+import _ from 'lodash';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Brush,
+} from 'recharts';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { colors } from '../../../styles/constants';
+import {
+  formatAxisCurrency,
+  formatAxisDate,
+  formatAxisNumber,
+} from '../../metrics/util';
+import AssetBridgingMetricsTooltip from './asset-bridging-metrics-tooltip';
+import ChartContainer from '../../../components/chart-container';
+import ChartPlaceholder from '../../../components/chart-placeholder';
+import useDisplayCurrency from '../../preferences/hooks/use-display-currency';
+
+const AssetBridgingMetricsChart = React.memo(
+  ({ data, granularity, onBrushChange, period, type }) => {
+    const displayCurrency = useDisplayCurrency();
+
+    if (_.isEmpty(data)) {
+      return <ChartPlaceholder>No data available</ChartPlaceholder>;
+    }
+
+    const sanitizedData = data.map((dataPoint) => ({
+      ...dataPoint,
+      date: dataPoint.date.toISOString(),
+    }));
+
+    return (
+      <ChartContainer>
+        <BarChart
+          data={sanitizedData}
+          margin={{ bottom: 0, left: 0, right: 0, top: 0 }}
+        >
+          <CartesianGrid
+            stroke={colors.athensGray}
+            strokeDasharray="8 8"
+            strokeOpacity={0.7}
+            vertical={false}
+          />
+          <Bar dataKey={type} fill={colors.anzac} fillOpacity={0.9} />
+          <XAxis
+            axisLine={{ stroke: colors.athensGray }}
+            dataKey="date"
+            tick={{ fill: 'currentColor', fontSize: '0.8em' }}
+            tickFormatter={(date) => formatAxisDate(date, period, granularity)}
+            tickLine={false}
+          />
+          <YAxis
+            axisLine={false}
+            dataKey={type}
+            mirror
+            scale="linear"
+            tick={{
+              fill: 'currentColor',
+              fontSize: '0.8em',
+              fontWeight: 'bold',
+            }}
+            tickFormatter={
+              type === 'tradeVolume' || type === 'protocolFees'
+                ? (value) => formatAxisCurrency(value, displayCurrency)
+                : formatAxisNumber
+            }
+            tickLine={false}
+          />
+          <Tooltip
+            content={
+              <AssetBridgingMetricsTooltip
+                currency={displayCurrency}
+                granularity={granularity}
+              />
+            }
+          />
+          <Brush
+            dataKey="date"
+            height={30}
+            onChange={onBrushChange}
+            stroke={colors.mischka}
+            tickFormatter={(date) => formatAxisDate(date, period, granularity)}
+          />
+        </BarChart>
+      </ChartContainer>
+    );
+  },
+);
+
+AssetBridgingMetricsChart.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      date: PropTypes.instanceOf(Date).isRequired,
+      tradeCount: PropTypes.number.isRequired,
+      tradeVolume: PropTypes.number.isRequired,
+    }),
+  ).isRequired,
+  granularity: PropTypes.string.isRequired,
+  onBrushChange: PropTypes.func,
+  period: PropTypes.string.isRequired,
+  type: PropTypes.string,
+};
+
+AssetBridgingMetricsChart.defaultProps = {
+  onBrushChange: undefined,
+  type: 'tradeVolume',
+};
+
+AssetBridgingMetricsChart.displayName = 'AssetBridgingMetricsChart';
+
+export default AssetBridgingMetricsChart;

--- a/src/features/asset-bridges/components/asset-bridging-metrics-tooltip.js
+++ b/src/features/asset-bridges/components/asset-bridging-metrics-tooltip.js
@@ -1,0 +1,52 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import formatCurrency from '../../../util/format-currency';
+import MetricsChartTooltip from '../../metrics/components/metrics-chart-tooltip';
+import Number from '../../../components/number';
+
+const AssetBridgingMetricsTooltip = ({ currency, granularity, payload }) => {
+  if (_.isEmpty(payload)) {
+    return null;
+  }
+
+  const { date, tradeCount, tradeVolume } = payload[0].payload;
+
+  return (
+    <MetricsChartTooltip
+      date={date}
+      granularity={granularity}
+      items={[
+        {
+          label: 'Trade Count',
+          value: <Number>{tradeCount}</Number>,
+        },
+        {
+          label: `Trade Volume (${currency})`,
+          value: formatCurrency(tradeVolume, currency),
+        },
+      ]}
+    />
+  );
+};
+
+AssetBridgingMetricsTooltip.propTypes = {
+  currency: PropTypes.string.isRequired,
+  granularity: PropTypes.string.isRequired,
+  payload: PropTypes.arrayOf(
+    PropTypes.shape({
+      payload: PropTypes.shape({
+        date: PropTypes.string.isRequired,
+        tradeCount: PropTypes.number.isRequired,
+        tradeVolume: PropTypes.number.isRequired,
+      }).isRequired,
+    }),
+  ),
+};
+
+AssetBridgingMetricsTooltip.defaultProps = {
+  payload: undefined,
+};
+
+export default AssetBridgingMetricsTooltip;

--- a/src/features/asset-bridges/components/asset-bridging-metrics.js
+++ b/src/features/asset-bridges/components/asset-bridging-metrics.js
@@ -1,0 +1,113 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { TIME_PERIOD } from '../../../constants';
+import BrushableChartContainer from '../../../components/brushable-chart-container';
+import createAsyncComponent from '../../../util/create-async-component';
+import LoadingIndicator from '../../../components/loading-indicator';
+import useConversionRate from '../../currencies/hooks/use-conversion-rate';
+import useAssetBridgingMetrics from '../hooks/use-asset-bridging-metrics';
+import useDisplayCurrency from '../../preferences/hooks/use-display-currency';
+
+const AsyncAssetBridgingMetricsChart = createAsyncComponent(() =>
+  import('./asset-bridging-metrics-chart'),
+);
+
+const determineGranularity = (period) => {
+  if (period === TIME_PERIOD.ALL) {
+    return 'month';
+  }
+
+  if (period === TIME_PERIOD.YEAR) {
+    return 'week';
+  }
+
+  if (period === TIME_PERIOD.MONTH) {
+    return 'day';
+  }
+
+  return 'hour';
+};
+
+const AssetBridgingMetrics = ({ period, type }) => {
+  const granularity = determineGranularity(period);
+  const [brushActive, setBrushActive] = React.useState(false);
+  const [metrics, loading] = useAssetBridgingMetrics(
+    { granularity, period },
+    { autoReload: !brushActive },
+  );
+  const conversionRate = useConversionRate();
+  const displayCurrency = useDisplayCurrency();
+
+  // This is a quick and dirty hack to implement brush resetting because Recharts
+  // doesn't allow us to control the brush indexes after mount. It works by modifying
+  // a chartKey value which is used as the key prop on AsyncNetworkMetricsChart below.
+  // When this key changes it will force a rerender of the chart.
+  const [chartKey, setChartKey] = React.useState(Date.now());
+  const handleResetClick = () => {
+    setBrushActive(false);
+    setChartKey(Date.now());
+  };
+
+  // The NetworkMetricsChart is designed to only rerender when one of its props changes. This
+  // is to prevent the brush position resetting when chart data hasn't changed. Because of this
+  // we must memoize the `handleBrushChange` and `data` props to ensure their references don't
+  // change each time this component rerenders (e.g. after the brushActive state changes).
+  const handleBrushChange = React.useCallback(() => {
+    setBrushActive(true);
+  }, []);
+
+  const data = React.useMemo(
+    () =>
+      (metrics || []).map((metric) => ({
+        date: new Date(metric.date),
+        tradeCount: metric.tradeCount,
+        tradeVolume: (parseFloat(metric.tradeVolume) || 0) * conversionRate,
+      })),
+    [metrics, conversionRate],
+  );
+
+  if (loading || conversionRate === undefined) {
+    return <LoadingIndicator centered />;
+  }
+
+  return (
+    <BrushableChartContainer
+      brushActive={brushActive}
+      onBrushReset={handleResetClick}
+    >
+      <AsyncAssetBridgingMetricsChart
+        currency={displayCurrency}
+        data={data}
+        granularity={granularity}
+        key={chartKey}
+        onBrushChange={handleBrushChange}
+        period={period}
+        type={type}
+      />
+    </BrushableChartContainer>
+  );
+};
+
+AssetBridgingMetrics.propTypes = {
+  period: PropTypes.string,
+  type: PropTypes.string,
+};
+
+AssetBridgingMetrics.defaultProps = {
+  period: TIME_PERIOD.MONTH,
+  type: 'tradeVolume',
+};
+
+// eslint-disable-next-line react/display-name, import/no-anonymous-default-export, react/prop-types, react/no-multi-comp
+export default ({ period, type }) => (
+  /*
+    This is a hack to ensure autoReload is reset whenever the period or type props are changed.
+    By using a key composed of period and type we can ensure the metrics component will remount
+    (and therefore reset state) whenever one of these props changes.
+
+    Ideally the autoReload state would be lifted up the component treet but I'm being lazy for
+    the time being because of the additional work involved.
+  */
+  <AssetBridgingMetrics key={`${period}_${type}`} period={period} type={type} />
+);

--- a/src/features/asset-bridges/components/asset-bridging-stats.js
+++ b/src/features/asset-bridges/components/asset-bridging-stats.js
@@ -1,0 +1,52 @@
+import { Col, Row } from 'reactstrap';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { useCurrentBreakpoint } from '../../../responsive-utils';
+import ActiveBridgesWidget from './active-bridges-widget';
+import BridgedTradesWidget from './bridged-trades-widget';
+import BridgedVolumeWidget from './bridged-volume-widget';
+import VolumeShareWidget from './volume-share-widget';
+
+// Carousel gets loaded lazily because it relies on react-slick
+// const AsyncTokenStatsCarousel = React.lazy(() =>
+//   import('./token-stats-carousel'),
+// );
+
+const AssetBridgingStats = ({ bridgeCount, trades, volume, volumeShare }) => {
+  const breakpoint = useCurrentBreakpoint();
+
+  return breakpoint.greaterThan('md') ? (
+    <Row css="margin-bottom: 2rem;">
+      <Col lg={3} md={6}>
+        <BridgedVolumeWidget volume={volume} />
+      </Col>
+      <Col lg={3} md={6}>
+        <VolumeShareWidget volumeShare={volumeShare} />
+      </Col>
+      <Col lg={3} md={6}>
+        <BridgedTradesWidget tradeCount={trades} />
+      </Col>
+      <Col lg={3} md={6}>
+        <ActiveBridgesWidget bridgeCount={bridgeCount} />
+      </Col>
+    </Row>
+  ) : null;
+  // <AsyncTokenStatsCarousel token={token} />
+};
+
+AssetBridgingStats.propTypes = {
+  bridgeCount: PropTypes.number,
+  trades: PropTypes.number,
+  volume: PropTypes.number,
+  volumeShare: PropTypes.number,
+};
+
+AssetBridgingStats.defaultProps = {
+  bridgeCount: undefined,
+  trades: undefined,
+  volume: undefined,
+  volumeShare: undefined,
+};
+
+export default AssetBridgingStats;

--- a/src/features/asset-bridges/components/asset-bridging-stats.js
+++ b/src/features/asset-bridges/components/asset-bridging-stats.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { Col, Row } from 'reactstrap';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -6,6 +7,7 @@ import { useCurrentBreakpoint } from '../../../responsive-utils';
 import ActiveBridgesWidget from './active-bridges-widget';
 import BridgedTradesWidget from './bridged-trades-widget';
 import BridgedVolumeWidget from './bridged-volume-widget';
+import useAssetBridgingStats from '../hooks/use-asset-bridging-stats';
 import VolumeShareWidget from './volume-share-widget';
 
 // Carousel gets loaded lazily because it relies on react-slick
@@ -13,19 +15,20 @@ import VolumeShareWidget from './volume-share-widget';
 //   import('./token-stats-carousel'),
 // );
 
-const AssetBridgingStats = ({ bridgeCount, trades, volume, volumeShare }) => {
+const AssetBridgingStats = ({ bridgeCount, period }) => {
+  const [stats] = useAssetBridgingStats(period);
   const breakpoint = useCurrentBreakpoint();
 
   return breakpoint.greaterThan('md') ? (
     <Row css="margin-bottom: 2rem;">
       <Col lg={3} md={6}>
-        <BridgedVolumeWidget volume={volume} />
+        <BridgedVolumeWidget volume={_.get(stats, 'tradeVolume')} />
       </Col>
       <Col lg={3} md={6}>
-        <VolumeShareWidget volumeShare={volumeShare} />
+        <VolumeShareWidget volumeShare={_.get(stats, 'tradeVolumeShare')} />
       </Col>
       <Col lg={3} md={6}>
-        <BridgedTradesWidget tradeCount={trades} />
+        <BridgedTradesWidget tradeCount={_.get(stats, 'tradeCount')} />
       </Col>
       <Col lg={3} md={6}>
         <ActiveBridgesWidget bridgeCount={bridgeCount} />
@@ -37,16 +40,11 @@ const AssetBridgingStats = ({ bridgeCount, trades, volume, volumeShare }) => {
 
 AssetBridgingStats.propTypes = {
   bridgeCount: PropTypes.number,
-  trades: PropTypes.number,
-  volume: PropTypes.number,
-  volumeShare: PropTypes.number,
+  period: PropTypes.string.isRequired,
 };
 
 AssetBridgingStats.defaultProps = {
   bridgeCount: undefined,
-  trades: undefined,
-  volume: undefined,
-  volumeShare: undefined,
 };
 
 export default AssetBridgingStats;

--- a/src/features/asset-bridges/components/bridged-trades-widget.js
+++ b/src/features/asset-bridges/components/bridged-trades-widget.js
@@ -13,7 +13,7 @@ const BridgedTradesWidget = ({ period, tradeCount, ...otherProps }) => (
   <StatWidget
     period={period}
     title="Bridged Trades"
-    tooltip="The total number of trades in the selected period which sourced liquidity from bridging contracts."
+    tooltip="The total number of trades which sourced liquidity from bridging contracts in the selected period."
     {...otherProps}
   >
     {_.isNumber(tradeCount) ? summarizeNumber(tradeCount) : loadingIndicator}

--- a/src/features/asset-bridges/components/bridged-trades-widget.js
+++ b/src/features/asset-bridges/components/bridged-trades-widget.js
@@ -1,0 +1,33 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { summarizeNumber } from '../../../util';
+import LoadingIndicator from '../../../components/loading-indicator';
+import sharedPropTypes from '../../../prop-types';
+import StatWidget from '../../../components/stat-widget';
+
+const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
+
+const BridgedTradesWidget = ({ period, tradeCount, ...otherProps }) => (
+  <StatWidget
+    period={period}
+    title="Bridged Trades"
+    tooltip="The total number of trades in the selected period which sourced liquidity from bridging contracts."
+    {...otherProps}
+  >
+    {_.isNumber(tradeCount) ? summarizeNumber(tradeCount) : loadingIndicator}
+  </StatWidget>
+);
+
+BridgedTradesWidget.propTypes = {
+  period: sharedPropTypes.timePeriod,
+  tradeCount: PropTypes.number,
+};
+
+BridgedTradesWidget.defaultProps = {
+  period: undefined,
+  tradeCount: undefined,
+};
+
+export default BridgedTradesWidget;

--- a/src/features/asset-bridges/components/bridged-volume-widget.js
+++ b/src/features/asset-bridges/components/bridged-volume-widget.js
@@ -13,7 +13,7 @@ const BridgedVolumeWidget = ({ period, volume, ...otherProps }) => (
   <StatWidget
     period={period}
     title="Bridged Volume"
-    tooltip="The total volume of all trades which involved liquidity sourced from bridging contracts."
+    tooltip="The total volume of all trades which involved liquidity sourced from bridging contracts in the selected period."
     {...otherProps}
   >
     {_.isNumber(volume) ? (

--- a/src/features/asset-bridges/components/bridged-volume-widget.js
+++ b/src/features/asset-bridges/components/bridged-volume-widget.js
@@ -1,0 +1,43 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import LoadingIndicator from '../../../components/loading-indicator';
+import LocalisedAmount from '../../currencies/components/localised-amount';
+import sharedPropTypes from '../../../prop-types';
+import StatWidget from '../../../components/stat-widget';
+
+const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
+
+const BridgedVolumeWidget = ({ period, volume, ...otherProps }) => (
+  <StatWidget
+    period={period}
+    title="Bridged Volume"
+    tooltip="The total value of all trades which involved liquidity sourced from bridging contracts."
+    {...otherProps}
+  >
+    {_.isNumber(volume) ? (
+      <LocalisedAmount
+        amount={volume}
+        loadingIndicator={loadingIndicator}
+        summarize
+      />
+    ) : (
+      loadingIndicator
+    )}
+  </StatWidget>
+);
+
+BridgedVolumeWidget.propTypes = {
+  className: PropTypes.string,
+  period: sharedPropTypes.timePeriod,
+  volume: PropTypes.number,
+};
+
+BridgedVolumeWidget.defaultProps = {
+  className: undefined,
+  period: undefined,
+  volume: undefined,
+};
+
+export default BridgedVolumeWidget;

--- a/src/features/asset-bridges/components/bridged-volume-widget.js
+++ b/src/features/asset-bridges/components/bridged-volume-widget.js
@@ -13,7 +13,7 @@ const BridgedVolumeWidget = ({ period, volume, ...otherProps }) => (
   <StatWidget
     period={period}
     title="Bridged Volume"
-    tooltip="The total value of all trades which involved liquidity sourced from bridging contracts."
+    tooltip="The total volume of all trades which involved liquidity sourced from bridging contracts."
     {...otherProps}
   >
     {_.isNumber(volume) ? (

--- a/src/features/asset-bridges/components/mini-bridge-metrics-chart.js
+++ b/src/features/asset-bridges/components/mini-bridge-metrics-chart.js
@@ -1,0 +1,51 @@
+import _ from 'lodash';
+import { Bar, BarChart } from 'recharts';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { colors } from '../../../styles/constants';
+
+const MiniBridgeMetricsChart = ({ data, height, type, width }) => {
+  if (_.isEmpty(data)) {
+    return null;
+  }
+
+  return (
+    <div
+      css={`
+        border-bottom: 1px solid ${colors.anzac};
+      `}
+    >
+      <BarChart
+        data={data.map((dataPoint) => ({
+          ...dataPoint,
+          date: dataPoint.date.toISOString(),
+        }))}
+        height={height}
+        margin={{ bottom: 0, left: 0, right: 0, top: 0 }}
+        width={width}
+      >
+        <Bar animationDuration={0} dataKey={type} fill={colors.anzac} />
+      </BarChart>
+    </div>
+  );
+};
+
+MiniBridgeMetricsChart.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      date: PropTypes.instanceOf(Date).isRequired,
+      tradeCount: PropTypes.number.isRequired,
+      tradeVolume: PropTypes.number.isRequired,
+    }),
+  ).isRequired,
+  height: PropTypes.number.isRequired,
+  type: PropTypes.oneOf(['tradeCount', 'tradeVolume']),
+  width: PropTypes.number.isRequired,
+};
+
+MiniBridgeMetricsChart.defaultProps = {
+  type: 'tradeVolume',
+};
+
+export default MiniBridgeMetricsChart;

--- a/src/features/asset-bridges/components/mini-bridge-metrics.js
+++ b/src/features/asset-bridges/components/mini-bridge-metrics.js
@@ -1,0 +1,62 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { METRIC_GRANULARITY, TIME_PERIOD } from '../../../constants';
+import createAsyncComponent from '../../../util/create-async-component';
+import useAssetBridgeMetrics from '../hooks/use-asset-bridge-metrics';
+import useConversionRate from '../../currencies/hooks/use-conversion-rate';
+
+const GRANULARITY_LOOKUP = {
+  [TIME_PERIOD.DAY]: METRIC_GRANULARITY.HOUR,
+  [TIME_PERIOD.WEEK]: METRIC_GRANULARITY.DAY,
+  [TIME_PERIOD.MONTH]: METRIC_GRANULARITY.DAY,
+  [TIME_PERIOD.YEAR]: METRIC_GRANULARITY.MONTH,
+  [TIME_PERIOD.ALL]: METRIC_GRANULARITY.MONTH,
+};
+
+const AsyncMiniBridgeMetricsChart = createAsyncComponent(() =>
+  import('./mini-bridge-metrics-chart'),
+);
+
+const MiniBridgeMetrics = ({ bridgeAddress, height, period, type, width }) => {
+  const [metrics, loading] = useAssetBridgeMetrics(bridgeAddress, {
+    granularity: GRANULARITY_LOOKUP[period],
+    period,
+  });
+  const conversionRate = useConversionRate();
+
+  const data = (metrics || []).map((metric) => ({
+    date: new Date(metric.date),
+    tradeCount: metric.tradeCount,
+    tradeVolume: (parseFloat(metric.tradeVolume) || 0) * conversionRate,
+  }));
+
+  if (loading || conversionRate === undefined) {
+    return null;
+  }
+
+  return (
+    <AsyncMiniBridgeMetricsChart
+      data={data}
+      fallback={null}
+      height={height}
+      type={type}
+      width={width}
+    />
+  );
+};
+
+MiniBridgeMetrics.propTypes = {
+  bridgeAddress: PropTypes.string.isRequired,
+  height: PropTypes.number.isRequired,
+  period: PropTypes.string,
+  type: PropTypes.string,
+  width: PropTypes.number.isRequired,
+};
+
+MiniBridgeMetrics.defaultProps = {
+  period: TIME_PERIOD.MONTH,
+  type: 'tradeVolume',
+};
+
+export default MiniBridgeMetrics;

--- a/src/features/asset-bridges/components/volume-share-widget.js
+++ b/src/features/asset-bridges/components/volume-share-widget.js
@@ -11,7 +11,7 @@ const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
 const VolumeShareWidget = ({ volumeShare, ...otherProps }) => (
   <StatWidget
     title="Bridging Dominance"
-    tooltip="The percentage of trading volume which was sourced from asset bridging contracts rather than regular wallets over the selected period."
+    tooltip="The percentage of trading volume sourced from asset bridging contracts rather than regular wallets in the selected period."
     {...otherProps}
   >
     {_.isNumber(volumeShare)

--- a/src/features/asset-bridges/components/volume-share-widget.js
+++ b/src/features/asset-bridges/components/volume-share-widget.js
@@ -1,0 +1,31 @@
+import _ from 'lodash';
+import numeral from 'numeral';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import LoadingIndicator from '../../../components/loading-indicator';
+import StatWidget from '../../../components/stat-widget';
+
+const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
+
+const VolumeShareWidget = ({ volumeShare, ...otherProps }) => (
+  <StatWidget
+    title="Volume Share"
+    tooltip="The percentage of total network volume which was sourced from asset bridging contracts."
+    {...otherProps}
+  >
+    {_.isNumber(volumeShare)
+      ? `${numeral(volumeShare).format('0.[00]')}%`
+      : loadingIndicator}
+  </StatWidget>
+);
+
+VolumeShareWidget.propTypes = {
+  volumeShare: PropTypes.number,
+};
+
+VolumeShareWidget.defaultProps = {
+  volumeShare: undefined,
+};
+
+export default VolumeShareWidget;

--- a/src/features/asset-bridges/components/volume-share-widget.js
+++ b/src/features/asset-bridges/components/volume-share-widget.js
@@ -11,7 +11,7 @@ const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
 const VolumeShareWidget = ({ volumeShare, ...otherProps }) => (
   <StatWidget
     title="Bridging Dominance"
-    tooltip="The percentage of total network volume which was sourced from asset bridging contracts rather than regular wallets."
+    tooltip="The percentage of trading volume which was sourced from asset bridging contracts rather than regular wallets over the selected period."
     {...otherProps}
   >
     {_.isNumber(volumeShare)

--- a/src/features/asset-bridges/components/volume-share-widget.js
+++ b/src/features/asset-bridges/components/volume-share-widget.js
@@ -10,8 +10,8 @@ const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
 
 const VolumeShareWidget = ({ volumeShare, ...otherProps }) => (
   <StatWidget
-    title="Volume Share"
-    tooltip="The percentage of total network volume which was sourced from asset bridging contracts."
+    title="Bridging Dominance"
+    tooltip="The percentage of total network volume which was sourced from asset bridging contracts rather than regular wallets."
     {...otherProps}
   >
     {_.isNumber(volumeShare)

--- a/src/features/asset-bridges/get-routes.js
+++ b/src/features/asset-bridges/get-routes.js
@@ -1,0 +1,10 @@
+import { URL } from '../../constants';
+
+const getRoutes = () => [
+  {
+    loader: () => import('./components/asset-bridges-page'),
+    path: URL.ASSET_BRIDGES,
+  },
+];
+
+export default getRoutes;

--- a/src/features/asset-bridges/hooks/use-asset-bridge-metrics.js
+++ b/src/features/asset-bridges/hooks/use-asset-bridge-metrics.js
@@ -1,0 +1,17 @@
+import useApi from '../../../hooks/use-api';
+
+const useAssetBridgeMetrics = (
+  bridgeAddress,
+  { granularity, period } = {},
+  { autoReload } = { autoReload: true },
+) =>
+  useApi('metrics/asset-bridge', {
+    autoReload,
+    params: {
+      address: bridgeAddress,
+      granularity,
+      period,
+    },
+  });
+
+export default useAssetBridgeMetrics;

--- a/src/features/asset-bridges/hooks/use-asset-bridges.js
+++ b/src/features/asset-bridges/hooks/use-asset-bridges.js
@@ -1,0 +1,25 @@
+import _ from 'lodash';
+
+import useApi from '../../../hooks/use-api';
+
+const useAssetBridges = (options = {}) => {
+  const [response, loading] = useApi('asset-bridges', {
+    autoReload: options.autoReload,
+    params: _.pick(options, ['limit', 'page', 'statsPeriod']),
+  });
+
+  const { limit, page, pageCount, assetBridges, total } = response || {};
+
+  return [
+    {
+      items: assetBridges,
+      page,
+      pageCount,
+      pageSize: limit,
+      recordCount: total,
+    },
+    loading,
+  ];
+};
+
+export default useAssetBridges;

--- a/src/features/asset-bridges/hooks/use-asset-bridging-metrics.js
+++ b/src/features/asset-bridges/hooks/use-asset-bridging-metrics.js
@@ -1,0 +1,15 @@
+import useApi from '../../../hooks/use-api';
+
+const useAssetBridgingMetrics = (
+  { granularity, period } = {},
+  { autoReload } = { autoReload: true },
+) =>
+  useApi('metrics/asset-bridging', {
+    autoReload,
+    params: {
+      granularity,
+      period,
+    },
+  });
+
+export default useAssetBridgingMetrics;

--- a/src/features/asset-bridges/hooks/use-asset-bridging-stats.js
+++ b/src/features/asset-bridges/hooks/use-asset-bridging-stats.js
@@ -1,0 +1,11 @@
+import useApi from '../../../hooks/use-api';
+
+const useAssetBridgingStats = (period) =>
+  useApi('stats/asset-bridging', {
+    autoReload: true,
+    params: {
+      period,
+    },
+  });
+
+export default useAssetBridgingStats;

--- a/src/features/header/components/mobile-navigation.js
+++ b/src/features/header/components/mobile-navigation.js
@@ -20,6 +20,7 @@ const MobileNavigation = ({ onNavigate }) => {
     <StyledNav aria-label="Primary">
       <ExpandableMobileNavigationItem
         items={[
+          { href: URL.ASSET_BRIDGES, title: 'Asset Bridges' },
           { href: URL.FILLS, title: 'Browse Fills' },
           { href: URL.NETWORK_INSIGHTS, title: 'Insights' },
           { href: URL.TRADERS, title: 'Top Traders' },

--- a/src/features/header/components/navigation.js
+++ b/src/features/header/components/navigation.js
@@ -16,6 +16,7 @@ const Navigation = ({ className }) => (
   <StyledNavigation aria-label="Primary" className={className}>
     <SubNavigationParent
       items={[
+        { href: URL.ASSET_BRIDGES, title: 'Asset Bridges' },
         { href: URL.FILLS, title: 'Browse Fills' },
         { href: URL.NETWORK_INSIGHTS, title: 'Insights' },
         { href: URL.TRADERS, title: 'Top Traders' },


### PR DESCRIPTION
This PR introduces a new page for monitoring the trading activity of asset bridges. Each asset bridge on the new page represents a single bridging contract.

Some thoughts on how the feature could be improved in the future:

* Add the option to group bridges by type (e.g. Kyber, Uniswap etc.)
* Visualise bridging dominance over time
* Provide an option for users to manually identify unknown contracts
* Extract destinations from DEX Forwarder activity

![asset birdges](https://user-images.githubusercontent.com/34132/79670236-233d2800-8187-11ea-963f-acc6bcdaa250.png)
