### PR TITLE
Add charts to traders page

### DIFF
--- a/src/features/traders/components/mini-trader-metrics-chart.js
+++ b/src/features/traders/components/mini-trader-metrics-chart.js
@@ -1,0 +1,58 @@
+import _ from 'lodash';
+import { Bar, BarChart } from 'recharts';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { COLORS } from '../../../styles/constants';
+
+const MiniTraderMetricsChart = ({ data, height, type, width }) => {
+  if (_.isEmpty(data)) {
+    return null;
+  }
+
+  return (
+    <div
+      css={`
+        border-bottom: 1px solid ${COLORS.ACCENT.ANZAC_200};
+      `}
+    >
+      <BarChart
+        data={data.map((dataPoint) => ({
+          ...dataPoint,
+          date: dataPoint.date.toISOString(),
+        }))}
+        height={height}
+        margin={{ bottom: 0, left: 0, right: 0, top: 0 }}
+        width={width}
+      >
+        <Bar
+          animationDuration={0}
+          dataKey={type}
+          fill={COLORS.ACCENT.ANZAC_500}
+        />
+      </BarChart>
+    </div>
+  );
+};
+
+MiniTraderMetricsChart.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      date: PropTypes.instanceOf(Date).isRequired,
+      fillCount: PropTypes.number.isRequired,
+      fillVolume: PropTypes.number.isRequired,
+      tradeCount: PropTypes.number.isRequired,
+      tradeVolume: PropTypes.number.isRequired,
+    }),
+  ).isRequired,
+  height: PropTypes.number.isRequired,
+  type: PropTypes.oneOf([
+    'fillCount',
+    'fillVolume',
+    'tradeCount',
+    'tradeVolume',
+  ]).isRequired,
+  width: PropTypes.number.isRequired,
+};
+
+export default MiniTraderMetricsChart;

--- a/src/features/traders/components/mini-trader-metrics.js
+++ b/src/features/traders/components/mini-trader-metrics.js
@@ -35,7 +35,11 @@ const MiniTraderMetrics = ({ address, height, period, type, width }) => {
       total: metric.fillVolume.total * conversionRate,
     },
     tradeCount: metric.tradeCount,
-    tradeVolume: (parseFloat(metric.tradeVolume) || 0) * conversionRate,
+    tradeVolume: {
+      maker: metric.tradeVolume.maker * conversionRate,
+      taker: metric.tradeVolume.taker * conversionRate,
+      total: metric.tradeVolume.total * conversionRate,
+    },
   }));
 
   if (loading || conversionRate === undefined) {

--- a/src/features/traders/components/mini-trader-metrics.js
+++ b/src/features/traders/components/mini-trader-metrics.js
@@ -1,0 +1,64 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { METRIC_GRANULARITY, TIME_PERIOD } from '../../../constants';
+import createAsyncComponent from '../../../util/create-async-component';
+import useConversionRate from '../../currencies/hooks/use-conversion-rate';
+import useTraderMetrics from '../hooks/use-trader-metrics';
+
+const GRANULARITY_LOOKUP = {
+  [TIME_PERIOD.DAY]: METRIC_GRANULARITY.HOUR,
+  [TIME_PERIOD.WEEK]: METRIC_GRANULARITY.DAY,
+  [TIME_PERIOD.MONTH]: METRIC_GRANULARITY.DAY,
+  [TIME_PERIOD.YEAR]: METRIC_GRANULARITY.MONTH,
+  [TIME_PERIOD.ALL]: METRIC_GRANULARITY.MONTH,
+};
+
+const AsyncMiniTraderMetricsChart = createAsyncComponent(() =>
+  import('./mini-trader-metrics-chart'),
+);
+
+const MiniTraderMetrics = ({ address, height, period, type, width }) => {
+  const [metrics, loading] = useTraderMetrics(address, {
+    granularity: GRANULARITY_LOOKUP[period],
+    period,
+  });
+
+  const conversionRate = useConversionRate();
+
+  const data = (metrics || []).map((metric) => ({
+    date: new Date(metric.date),
+    fillCount: metric.fillCount,
+    fillVolume: {
+      maker: metric.fillVolume.maker * conversionRate,
+      taker: metric.fillVolume.taker * conversionRate,
+      total: metric.fillVolume.total * conversionRate,
+    },
+    tradeCount: metric.tradeCount,
+    tradeVolume: (parseFloat(metric.tradeVolume) || 0) * conversionRate,
+  }));
+
+  if (loading || conversionRate === undefined) {
+    return null;
+  }
+
+  return (
+    <AsyncMiniTraderMetricsChart
+      data={data}
+      fallback={null}
+      height={height}
+      type={type}
+      width={width}
+    />
+  );
+};
+
+MiniTraderMetrics.propTypes = {
+  address: PropTypes.string.isRequired,
+  height: PropTypes.number.isRequired,
+  period: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  width: PropTypes.number.isRequired,
+};
+
+export default MiniTraderMetrics;

--- a/src/features/traders/components/trader-list.js
+++ b/src/features/traders/components/trader-list.js
@@ -5,6 +5,7 @@ import { COLORS } from '../../../styles/constants';
 import { ExternalLinkIcon, MoreIcon } from '../../../components/icons';
 import Badge from '../../../components/badge';
 import Blockie from '../../../components/blockie';
+import HelpWidget from '../../../components/help-widget';
 import Link from '../../../components/link';
 import Rank from '../../../components/rank';
 import Tooltip from '../../../components/tooltip';
@@ -12,17 +13,34 @@ import tradersPropTypes from '../prop-types';
 import TraderLink from './trader-link';
 import TraderFillCountLabel from './trader-fill-count-label';
 import TraderVolumeLabel from './trader-volume-label';
+import MiniTraderMetrics from './mini-trader-metrics';
 
-const TraderList = ({ positionOffset, traders }) => (
+const TraderList = ({ positionOffset, statsPeriod, traders }) => (
   <table className="table table-responsive">
     <thead>
       <tr>
-        <th className="align-middle text-center">#</th>
-        <th className="align-middle" colSpan={2}>
-          Trader
+        <th className="text-center">#</th>
+        <th colSpan={2}>Trader</th>
+        <th className="text-center">
+          Fills
+          <HelpWidget css="margin-left: 0.25rem;">
+            The number of unique fills for a given trader in the selected
+            period.
+          </HelpWidget>
         </th>
-        <th className="text-center">Fills</th>
-        <th className="text-center">Volume</th>
+        <th className="text-center">
+          Volume
+          <HelpWidget css="margin-left: 0.25rem;">
+            The total value of all fills that a given trader participated in for
+            the selected period.
+          </HelpWidget>
+        </th>
+        <th>
+          Volume Trend
+          <HelpWidget css="margin-left: 0.25rem;">
+            Volume trend for a given trader in the selected period.
+          </HelpWidget>
+        </th>
         <th title="Actions" />
       </tr>
     </thead>
@@ -71,6 +89,15 @@ const TraderList = ({ positionOffset, traders }) => (
           <td className="align-middle text-center" side="left">
             <TraderVolumeLabel volume={trader.stats.fillVolume} />
           </td>
+          <td>
+            <MiniTraderMetrics
+              address={trader.address}
+              height={40}
+              period={statsPeriod}
+              type="fillVolume.total"
+              width={120}
+            />
+          </td>
           <td className="align-middle text-center">
             <Tooltip content="View Detail">
               <span>
@@ -114,6 +141,7 @@ const TraderList = ({ positionOffset, traders }) => (
 
 TraderList.propTypes = {
   positionOffset: PropTypes.number,
+  statsPeriod: PropTypes.string.isRequired,
   traders: PropTypes.arrayOf(tradersPropTypes.traderWithStats).isRequired,
 };
 

--- a/src/features/traders/components/traders-page.js
+++ b/src/features/traders/components/traders-page.js
@@ -3,8 +3,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { TIME_PERIOD, URL } from '../../../constants';
+import { media } from '../../../styles/util';
+import ActiveTraderMetrics from '../../metrics/components/active-trader-metrics';
 import buildUrl from '../../../util/build-url';
 import Card from '../../../components/card';
+import CardBody from '../../../components/card-body';
 import Hidden from '../../../components/hidden';
 import LoadingIndicator from '../../../components/loading-indicator';
 import PageLayout from '../../../components/page-layout';
@@ -15,7 +18,7 @@ import TradersFilter from './traders-filter';
 import useTraders from '../hooks/use-traders';
 
 const defaultFilters = {
-  statsPeriod: TIME_PERIOD.DAY,
+  statsPeriod: TIME_PERIOD.MONTH,
   type: undefined,
 };
 
@@ -71,32 +74,48 @@ const TradersPage = ({ history, location }) => {
           </span>
         }
       >
-        <Card fullHeight>
-          {loading ? (
-            <LoadingIndicator centered />
-          ) : (
-            <>
-              <TraderList
-                positionOffset={(page - 1) * pageSize}
-                traders={items}
-              />
-              <Paginator
-                onPageChange={(newPage) => {
-                  history.push(
-                    buildUrl(URL.TRADERS, {
-                      page: newPage,
-                      ...selectedFilters,
-                    }),
-                  );
-                }}
-                page={page}
-                pageCount={pageCount}
-                pageSize={pageSize}
-                recordCount={recordCount}
-              />
-            </>
-          )}
-        </Card>
+        <>
+          <Card
+            css={`
+              height: 300px;
+              margin-bottom: 1.25rem;
+
+              ${media.greaterThan('lg')`
+                margin-bottom: 2rem;
+              `}
+            `}
+          >
+            <CardBody padded>
+              <ActiveTraderMetrics period={statsPeriod} />
+            </CardBody>
+          </Card>
+          <Card fullHeight>
+            {loading ? (
+              <LoadingIndicator centered />
+            ) : (
+              <>
+                <TraderList
+                  positionOffset={(page - 1) * pageSize}
+                  traders={items}
+                />
+                <Paginator
+                  onPageChange={(newPage) => {
+                    history.push(
+                      buildUrl(URL.TRADERS, {
+                        page: newPage,
+                        ...selectedFilters,
+                      }),
+                    );
+                  }}
+                  page={page}
+                  pageCount={pageCount}
+                  pageSize={pageSize}
+                  recordCount={recordCount}
+                />
+              </>
+            )}
+          </Card>
+        </>
       </PageLayout>
     </>
   );

--- a/src/features/traders/components/traders-page.js
+++ b/src/features/traders/components/traders-page.js
@@ -1,3 +1,4 @@
+import { Col, Row } from 'reactstrap';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -8,11 +9,14 @@ import { useMetadata } from '../../../hooks';
 import ActiveTraderMetrics from '../../metrics/components/active-trader-metrics';
 import Card from '../../../components/card';
 import CardBody from '../../../components/card-body';
+import CardHeader from '../../../components/card-header';
+import CardHeading from '../../../components/card-heading';
 import Hidden from '../../../components/hidden';
 import LoadingIndicator from '../../../components/loading-indicator';
 import PageLayout from '../../../components/page-layout';
 import Paginator from '../../../components/paginator';
 import SubTitle from '../../../components/sub-title';
+import TraderBreakdown from './trader-breakdown';
 import TraderList from './trader-list';
 import TradersFilter from './traders-filter';
 import useTraders from '../hooks/use-traders';
@@ -73,20 +77,46 @@ const TradersPage = ({ history, location }) => {
       }
     >
       <>
-        <Card
-          css={`
-            height: 300px;
-            margin-bottom: 1.25rem;
+        <Row>
+          <Col lg={7}>
+            <Card
+              css={`
+                height: 300px;
+                margin-bottom: 1.25rem;
 
-            ${media.greaterThan('lg')`
+                ${media.greaterThan('lg')`
                 margin-bottom: 2rem;
               `}
-          `}
-        >
-          <CardBody padded>
-            <ActiveTraderMetrics period={statsPeriod} />
-          </CardBody>
-        </Card>
+              `}
+            >
+              <CardHeader>
+                <CardHeading>Trend</CardHeading>
+              </CardHeader>
+              <CardBody padded>
+                <ActiveTraderMetrics period={statsPeriod} />
+              </CardBody>
+            </Card>
+          </Col>
+          <Col lg={5}>
+            <Card
+              css={`
+                height: 300px;
+                margin-bottom: 1.25rem;
+
+                ${media.greaterThan('lg')`
+                margin-bottom: 2rem;
+              `}
+              `}
+            >
+              <CardHeader>
+                <CardHeading>Maker-Taker Split</CardHeading>
+              </CardHeader>
+              <CardBody css="padding: 3rem;">
+                <TraderBreakdown period={statsPeriod} />
+              </CardBody>
+            </Card>
+          </Col>
+        </Row>
         <Card fullHeight>
           {loading ? (
             <LoadingIndicator centered />
@@ -94,6 +124,7 @@ const TradersPage = ({ history, location }) => {
             <>
               <TraderList
                 positionOffset={(page - 1) * pageSize}
+                statsPeriod={statsPeriod}
                 traders={items}
               />
               <Paginator

--- a/src/features/traders/hooks/use-trader-metrics.js
+++ b/src/features/traders/hooks/use-trader-metrics.js
@@ -1,0 +1,17 @@
+import useApi from '../../../hooks/use-api';
+
+const useTraderMetrics = (
+  address,
+  { granularity, period } = {},
+  { autoReload } = { autoReload: true },
+) =>
+  useApi('metrics/trader', {
+    autoReload,
+    params: {
+      address,
+      granularity,
+      period,
+    },
+  });
+
+export default useTraderMetrics;


### PR DESCRIPTION
This PR adds some additional charts to the traders page to provide greater insight into activity during the selected period. 

The charts are as follows:

* Active traders over time
* Maker-taker split
* Per trader volume trend

<img width="1440" alt="Screenshot 2020-04-27 at 18 04 12" src="https://user-images.githubusercontent.com/34132/80429440-b4ac4880-88b1-11ea-89b9-80485942389b.png">
