### PR TITLE
Add percentage change indicators to stat widgets

### DIFF
--- a/src/components/percentage-change.js
+++ b/src/components/percentage-change.js
@@ -17,7 +17,7 @@ const getColor = (value) => {
   return COLORS.NEUTRAL.MYSTIC_600;
 };
 
-const PriceChange = ({ children, className }) => {
+const PercentageChange = ({ children, className }) => {
   if (children === null) {
     return null;
   }
@@ -60,9 +60,9 @@ const PriceChange = ({ children, className }) => {
   );
 };
 
-PriceChange.propTypes = {
+PercentageChange.propTypes = {
   children: PropTypes.number.isRequired,
   className: PropTypes.string, // eslint-disable-line react/require-default-props
 };
 
-export default PriceChange;
+export default PercentageChange;

--- a/src/components/price-change.js
+++ b/src/components/price-change.js
@@ -17,42 +17,48 @@ const getColor = (value) => {
   return COLORS.NEUTRAL.MYSTIC_600;
 };
 
-const PriceChange = ({ children, className }) => (
-  <span
-    className={className}
-    css={`
-      color: ${getColor(children)};
-      margin-left: 0.5rem;
-      font-size: 1rem;
-    `}
-  >
-    {numeral(children).format('0.[00]')}%
-    {children === 0 ? (
-      <TrendingFlatIcon
-        color="currentColor"
-        css="margin: 0 0 0 0.25rem;"
-        height={20}
-        width={20}
-      />
-    ) : null}
-    {children > 0 ? (
-      <TrendingUpIcon
-        color="currentColor"
-        css="margin: 0 0 0 0.25rem;"
-        height={20}
-        width={20}
-      />
-    ) : null}
-    {children < 0 ? (
-      <TrendingDownIcon
-        color="currentColor"
-        css="margin: 0 0 0 0.25rem;"
-        height={20}
-        width={20}
-      />
-    ) : null}
-  </span>
-);
+const PriceChange = ({ children, className }) => {
+  if (children === null) {
+    return null;
+  }
+
+  return (
+    <span
+      className={className}
+      css={`
+        color: ${getColor(children)};
+        margin-left: 0.5rem;
+        font-size: 1rem;
+      `}
+    >
+      {numeral(children).format('0.[00]')}%
+      {children === 0 ? (
+        <TrendingFlatIcon
+          color="currentColor"
+          css="margin: 0 0 0 0.25rem;"
+          height={20}
+          width={20}
+        />
+      ) : null}
+      {children > 0 ? (
+        <TrendingUpIcon
+          color="currentColor"
+          css="margin: 0 0 0 0.25rem;"
+          height={20}
+          width={20}
+        />
+      ) : null}
+      {children < 0 ? (
+        <TrendingDownIcon
+          color="currentColor"
+          css="margin: 0 0 0 0.25rem;"
+          height={20}
+          width={20}
+        />
+      ) : null}
+    </span>
+  );
+};
 
 PriceChange.propTypes = {
   children: PropTypes.number.isRequired,

--- a/src/features/asset-bridges/components/asset-bridging-stats.js
+++ b/src/features/asset-bridges/components/asset-bridging-stats.js
@@ -20,18 +20,21 @@ const AssetBridgingStats = ({ bridgeCount, period }) => {
       <CardGridRow minHeight="80px">
         <CardGridCol lg={3} md={6}>
           <BridgedVolumeWidget
+            change={_.get(stats, 'tradeVolumeChange')}
             loading={loading}
             volume={_.get(stats, 'tradeVolume')}
           />
         </CardGridCol>
         <CardGridCol lg={3} md={6}>
           <VolumeShareWidget
+            change={_.get(stats, 'tradeVolumeShareChange')}
             loading={loading}
             volumeShare={_.get(stats, 'tradeVolumeShare')}
           />
         </CardGridCol>
         <CardGridCol lg={3} md={6}>
           <BridgedTradesWidget
+            change={_.get(stats, 'tradeCountChange')}
             loading={loading}
             tradeCount={_.get(stats, 'tradeCount')}
           />

--- a/src/features/asset-bridges/components/bridged-trades-widget.js
+++ b/src/features/asset-bridges/components/bridged-trades-widget.js
@@ -4,28 +4,38 @@ import React from 'react';
 
 import { summarizeNumber } from '../../../util';
 import LoadingIndicator from '../../../components/loading-indicator';
+import PriceChange from '../../../components/price-change';
 import sharedPropTypes from '../../../prop-types';
 import StatWidget from '../../../components/stat-widget';
 
 const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
 
-const BridgedTradesWidget = ({ period, tradeCount, ...otherProps }) => (
+const BridgedTradesWidget = ({ change, period, tradeCount, ...otherProps }) => (
   <StatWidget
     period={period}
     title="Bridged Trades"
     tooltip="The total number of trades which sourced liquidity from bridging contracts in the selected period."
     {...otherProps}
   >
-    {_.isNumber(tradeCount) ? summarizeNumber(tradeCount) : loadingIndicator}
+    {_.isNumber(tradeCount) ? (
+      <span css="align-items: baseline; display: flex;">
+        {summarizeNumber(tradeCount)}
+        {change !== undefined && <PriceChange>{change}</PriceChange>}
+      </span>
+    ) : (
+      loadingIndicator
+    )}
   </StatWidget>
 );
 
 BridgedTradesWidget.propTypes = {
+  change: PropTypes.number,
   period: sharedPropTypes.timePeriod,
   tradeCount: PropTypes.number,
 };
 
 BridgedTradesWidget.defaultProps = {
+  change: undefined,
   period: undefined,
   tradeCount: undefined,
 };

--- a/src/features/asset-bridges/components/bridged-trades-widget.js
+++ b/src/features/asset-bridges/components/bridged-trades-widget.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { summarizeNumber } from '../../../util';
 import LoadingIndicator from '../../../components/loading-indicator';
-import PriceChange from '../../../components/price-change';
+import PercentageChange from '../../../components/percentage-change';
 import sharedPropTypes from '../../../prop-types';
 import StatWidget from '../../../components/stat-widget';
 
@@ -20,7 +20,7 @@ const BridgedTradesWidget = ({ change, period, tradeCount, ...otherProps }) => (
     {_.isNumber(tradeCount) ? (
       <span css="align-items: baseline; display: flex;">
         {summarizeNumber(tradeCount)}
-        {change !== undefined && <PriceChange>{change}</PriceChange>}
+        {change !== undefined && <PercentageChange>{change}</PercentageChange>}
       </span>
     ) : (
       loadingIndicator

--- a/src/features/asset-bridges/components/bridged-volume-widget.js
+++ b/src/features/asset-bridges/components/bridged-volume-widget.js
@@ -4,12 +4,13 @@ import React from 'react';
 
 import LoadingIndicator from '../../../components/loading-indicator';
 import LocalisedAmount from '../../currencies/components/localised-amount';
+import PriceChange from '../../../components/price-change';
 import sharedPropTypes from '../../../prop-types';
 import StatWidget from '../../../components/stat-widget';
 
 const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
 
-const BridgedVolumeWidget = ({ period, volume, ...otherProps }) => (
+const BridgedVolumeWidget = ({ change, period, volume, ...otherProps }) => (
   <StatWidget
     period={period}
     title="Bridged Volume"
@@ -17,11 +18,14 @@ const BridgedVolumeWidget = ({ period, volume, ...otherProps }) => (
     {...otherProps}
   >
     {_.isNumber(volume) ? (
-      <LocalisedAmount
-        amount={volume}
-        loadingIndicator={loadingIndicator}
-        summarize
-      />
+      <span css="align-items: baseline; display: flex;">
+        <LocalisedAmount
+          amount={volume}
+          loadingIndicator={loadingIndicator}
+          summarize
+        />
+        {change !== undefined && <PriceChange>{change}</PriceChange>}
+      </span>
     ) : (
       loadingIndicator
     )}
@@ -29,12 +33,14 @@ const BridgedVolumeWidget = ({ period, volume, ...otherProps }) => (
 );
 
 BridgedVolumeWidget.propTypes = {
+  change: PropTypes.number,
   className: PropTypes.string,
   period: sharedPropTypes.timePeriod,
   volume: PropTypes.number,
 };
 
 BridgedVolumeWidget.defaultProps = {
+  change: undefined,
   className: undefined,
   period: undefined,
   volume: undefined,

--- a/src/features/asset-bridges/components/bridged-volume-widget.js
+++ b/src/features/asset-bridges/components/bridged-volume-widget.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import LoadingIndicator from '../../../components/loading-indicator';
 import LocalisedAmount from '../../currencies/components/localised-amount';
-import PriceChange from '../../../components/price-change';
+import PercentageChange from '../../../components/percentage-change';
 import sharedPropTypes from '../../../prop-types';
 import StatWidget from '../../../components/stat-widget';
 
@@ -24,7 +24,7 @@ const BridgedVolumeWidget = ({ change, period, volume, ...otherProps }) => (
           loadingIndicator={loadingIndicator}
           summarize
         />
-        {change !== undefined && <PriceChange>{change}</PriceChange>}
+        {change !== undefined && <PercentageChange>{change}</PercentageChange>}
       </span>
     ) : (
       loadingIndicator

--- a/src/features/asset-bridges/components/volume-share-widget.js
+++ b/src/features/asset-bridges/components/volume-share-widget.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import LoadingIndicator from '../../../components/loading-indicator';
-import PriceChange from '../../../components/price-change';
+import PercentageChange from '../../../components/percentage-change';
 import StatWidget from '../../../components/stat-widget';
 
 const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
@@ -18,7 +18,7 @@ const VolumeShareWidget = ({ change, volumeShare, ...otherProps }) => (
     {_.isNumber(volumeShare) ? (
       <span css="align-items: baseline; display: flex;">
         {numeral(volumeShare).format('0.[00]')}%
-        <PriceChange>{change}</PriceChange>
+        <PercentageChange>{change}</PercentageChange>
       </span>
     ) : (
       loadingIndicator

--- a/src/features/asset-bridges/components/volume-share-widget.js
+++ b/src/features/asset-bridges/components/volume-share-widget.js
@@ -4,27 +4,35 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import LoadingIndicator from '../../../components/loading-indicator';
+import PriceChange from '../../../components/price-change';
 import StatWidget from '../../../components/stat-widget';
 
 const loadingIndicator = <LoadingIndicator size="small" type="cylon" />;
 
-const VolumeShareWidget = ({ volumeShare, ...otherProps }) => (
+const VolumeShareWidget = ({ change, volumeShare, ...otherProps }) => (
   <StatWidget
     title="Bridging Dominance"
     tooltip="The percentage of trading volume sourced from asset bridging contracts rather than regular wallets in the selected period."
     {...otherProps}
   >
-    {_.isNumber(volumeShare)
-      ? `${numeral(volumeShare).format('0.[00]')}%`
-      : loadingIndicator}
+    {_.isNumber(volumeShare) ? (
+      <span css="align-items: baseline; display: flex;">
+        {numeral(volumeShare).format('0.[00]')}%
+        <PriceChange>{change}</PriceChange>
+      </span>
+    ) : (
+      loadingIndicator
+    )}
   </StatWidget>
 );
 
 VolumeShareWidget.propTypes = {
+  change: PropTypes.number,
   volumeShare: PropTypes.number,
 };
 
 VolumeShareWidget.defaultProps = {
+  change: undefined,
   volumeShare: undefined,
 };
 

--- a/src/features/fills/components/trade-count-widget.js
+++ b/src/features/fills/components/trade-count-widget.js
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { summarizeNumber } from '../../../util';
 import LoadingIndicator from '../../../components/loading-indicator';
+import PriceChange from '../../../components/price-change';
 import sharedPropTypes from '../../../prop-types';
 import StatWidget from '../../../components/stat-widget';
 
@@ -17,23 +18,32 @@ const createTooltip = (period) => {
   return `Total number of trades in the last ${period}.`;
 };
 
-const TradeCountWidget = ({ period, tradeCount, ...otherProps }) => (
+const TradeCountWidget = ({ change, period, tradeCount, ...otherProps }) => (
   <StatWidget
     period={period}
     title="Trades"
     tooltip={createTooltip(period)}
     {...otherProps}
   >
-    {_.isNumber(tradeCount) ? summarizeNumber(tradeCount) : loadingIndicator}
+    {_.isNumber(tradeCount) ? (
+      <span css="align-items: baseline; display: flex;">
+        {summarizeNumber(tradeCount)}
+        {change !== undefined && <PriceChange>{change}</PriceChange>}
+      </span>
+    ) : (
+      loadingIndicator
+    )}
   </StatWidget>
 );
 
 TradeCountWidget.propTypes = {
+  change: PropTypes.number,
   period: sharedPropTypes.timePeriod,
   tradeCount: PropTypes.number,
 };
 
 TradeCountWidget.defaultProps = {
+  change: undefined,
   period: undefined,
   tradeCount: undefined,
 };

--- a/src/features/fills/components/trade-count-widget.js
+++ b/src/features/fills/components/trade-count-widget.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { summarizeNumber } from '../../../util';
 import LoadingIndicator from '../../../components/loading-indicator';
-import PriceChange from '../../../components/price-change';
+import PercentageChange from '../../../components/percentage-change';
 import sharedPropTypes from '../../../prop-types';
 import StatWidget from '../../../components/stat-widget';
 
@@ -28,7 +28,7 @@ const TradeCountWidget = ({ change, period, tradeCount, ...otherProps }) => (
     {_.isNumber(tradeCount) ? (
       <span css="align-items: baseline; display: flex;">
         {summarizeNumber(tradeCount)}
-        {change !== undefined && <PriceChange>{change}</PriceChange>}
+        {change !== undefined && <PercentageChange>{change}</PercentageChange>}
       </span>
     ) : (
       loadingIndicator

--- a/src/features/fills/components/trade-volume-widget.js
+++ b/src/features/fills/components/trade-volume-widget.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import LoadingIndicator from '../../../components/loading-indicator';
 import LocalisedAmount from '../../currencies/components/localised-amount';
-import PriceChange from '../../../components/price-change';
+import PercentageChange from '../../../components/percentage-change';
 import sharedPropTypes from '../../../prop-types';
 import StatWidget from '../../../components/stat-widget';
 
@@ -32,7 +32,7 @@ const TradeVolumeWidget = ({ change, period, volume, ...otherProps }) => (
           loadingIndicator={loadingIndicator}
           summarize
         />
-        {change !== undefined && <PriceChange>{change}</PriceChange>}
+        {change !== undefined && <PercentageChange>{change}</PercentageChange>}
       </span>
     ) : (
       loadingIndicator

--- a/src/features/fills/components/trade-volume-widget.js
+++ b/src/features/fills/components/trade-volume-widget.js
@@ -4,6 +4,7 @@ import React from 'react';
 
 import LoadingIndicator from '../../../components/loading-indicator';
 import LocalisedAmount from '../../currencies/components/localised-amount';
+import PriceChange from '../../../components/price-change';
 import sharedPropTypes from '../../../prop-types';
 import StatWidget from '../../../components/stat-widget';
 
@@ -17,7 +18,7 @@ const createTooltip = (period) => {
   return `Total value of all trades in the last ${period}.`;
 };
 
-const TradeVolumeWidget = ({ period, volume, ...otherProps }) => (
+const TradeVolumeWidget = ({ change, period, volume, ...otherProps }) => (
   <StatWidget
     period={period}
     title="Volume"
@@ -25,11 +26,14 @@ const TradeVolumeWidget = ({ period, volume, ...otherProps }) => (
     {...otherProps}
   >
     {_.isNumber(volume) ? (
-      <LocalisedAmount
-        amount={volume}
-        loadingIndicator={loadingIndicator}
-        summarize
-      />
+      <span css="align-items: baseline; display: flex;">
+        <LocalisedAmount
+          amount={volume}
+          loadingIndicator={loadingIndicator}
+          summarize
+        />
+        {change !== undefined && <PriceChange>{change}</PriceChange>}
+      </span>
     ) : (
       loadingIndicator
     )}
@@ -37,12 +41,14 @@ const TradeVolumeWidget = ({ period, volume, ...otherProps }) => (
 );
 
 TradeVolumeWidget.propTypes = {
+  change: PropTypes.number,
   className: PropTypes.string,
   period: sharedPropTypes.timePeriod,
   volume: PropTypes.number,
 };
 
 TradeVolumeWidget.defaultProps = {
+  change: undefined,
   className: undefined,
   period: undefined,
   volume: undefined,

--- a/src/features/home/components/home-page-metrics-carousel.js
+++ b/src/features/home/components/home-page-metrics-carousel.js
@@ -19,8 +19,11 @@ const CarouselMetric = styled.div`
 const HomePageMetricsCarousel = ({
   period,
   tradeCount,
+  tradeCountChange,
   traderCount,
+  traderCountChange,
   tradeVolume,
+  tradeVolumeChange,
 }) => (
   <Slider
     arrows={false}
@@ -43,16 +46,19 @@ const HomePageMetricsCarousel = ({
   >
     <CarouselMetric
       as={TradeVolumeWidget}
+      change={tradeVolumeChange}
       period={period}
       volume={tradeVolume}
     />
     <CarouselMetric
       as={TradeCountWidget}
+      change={tradeCountChange}
       period={period}
       tradeCount={tradeCount}
     />
     <CarouselMetric
       as={ActiveTradersWidget}
+      change={traderCountChange}
       period={period}
       traderCount={traderCount}
     />
@@ -63,14 +69,20 @@ const HomePageMetricsCarousel = ({
 HomePageMetricsCarousel.propTypes = {
   period: sharedPropTypes.timePeriod.isRequired,
   tradeCount: PropTypes.number,
+  tradeCountChange: PropTypes.number,
   tradeVolume: PropTypes.number,
+  tradeVolumeChange: PropTypes.number,
   traderCount: PropTypes.number,
+  traderCountChange: PropTypes.number,
 };
 
 HomePageMetricsCarousel.defaultProps = {
   tradeCount: undefined,
+  tradeCountChange: undefined,
   tradeVolume: undefined,
+  tradeVolumeChange: undefined,
   traderCount: undefined,
+  traderCountChange: undefined,
 };
 
 export default HomePageMetricsCarousel;

--- a/src/features/home/components/home-page-metrics.js
+++ b/src/features/home/components/home-page-metrics.js
@@ -61,8 +61,11 @@ const HomePageMetrics = () => {
     <HomePageMetricsCarousel
       period={statsParams.period}
       tradeCount={tradeCount}
+      tradeCountChange={tradeCountChange}
       traderCount={traderCount}
+      traderCountChange={traderCountChange}
       tradeVolume={tradeVolume}
+      tradeVolumeChange={tradeVolumeChange}
     />
   );
 };

--- a/src/features/home/components/home-page-metrics.js
+++ b/src/features/home/components/home-page-metrics.js
@@ -21,13 +21,17 @@ const HomePageMetrics = () => {
   const breakpoint = useCurrentBreakpoint();
 
   const tradeCount = _.get(networkStats, 'tradeCount');
+  const tradeCountChange = _.get(networkStats, 'tradeCountChange');
   const traderCount = _.get(traderStats, 'traderCount');
+  const traderCountChange = _.get(traderStats, 'traderCountChange');
   const tradeVolume = _.get(networkStats, 'tradeVolume');
+  const tradeVolumeChange = _.get(networkStats, 'tradeVolumeChange');
 
   return breakpoint.greaterThan('md') ? (
     <CardGridRow minHeight="80px">
       <CardGridCol lg={3} md={6}>
         <TradeVolumeWidget
+          change={tradeVolumeChange}
           loading={loadingNetworkStats}
           period={statsParams.period}
           volume={tradeVolume}
@@ -35,6 +39,7 @@ const HomePageMetrics = () => {
       </CardGridCol>
       <CardGridCol lg={3} md={6}>
         <TradeCountWidget
+          change={tradeCountChange}
           loading={loadingNetworkStats}
           period={statsParams.period}
           tradeCount={tradeCount}
@@ -42,6 +47,7 @@ const HomePageMetrics = () => {
       </CardGridCol>
       <CardGridCol lg={3} md={6}>
         <ActiveTradersWidget
+          change={traderCountChange}
           loading={loadingTraderStats}
           period={statsParams.period}
           traderCount={traderCount}

--- a/src/features/home/components/zrx-price-widget.js
+++ b/src/features/home/components/zrx-price-widget.js
@@ -12,7 +12,10 @@ const ZRXPriceWidget = (props) => {
   return (
     <StatWidget {...props} loading={loading} title="ZRX Price">
       {!loading && (
-        <Link href="https://www.cryptocompare.com/coins/zrx/overview">
+        <Link
+          css="align-items: baseline; display: flex;"
+          href="https://www.cryptocompare.com/coins/zrx/overview"
+        >
           <LocalisedAmount amount={zrxPrice.value} preferredPrecision={5} />
           <PriceChange>{zrxPrice.change}</PriceChange>
         </Link>

--- a/src/features/home/components/zrx-price-widget.js
+++ b/src/features/home/components/zrx-price-widget.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Link from '../../../components/link';
 import LocalisedAmount from '../../currencies/components/localised-amount';
-import PriceChange from '../../../components/price-change';
+import PercentageChange from '../../../components/percentage-change';
 import StatWidget from '../../../components/stat-widget';
 import useZrxPrice from '../hooks/use-zrx-price';
 
@@ -17,7 +17,7 @@ const ZRXPriceWidget = (props) => {
           href="https://www.cryptocompare.com/coins/zrx/overview"
         >
           <LocalisedAmount amount={zrxPrice.value} preferredPrecision={5} />
-          <PriceChange>{zrxPrice.change}</PriceChange>
+          <PercentageChange>{zrxPrice.change}</PercentageChange>
         </Link>
       )}
     </StatWidget>

--- a/src/features/network-overview/components/network-overview-stats-carousel.js
+++ b/src/features/network-overview/components/network-overview-stats-carousel.js
@@ -17,9 +17,13 @@ const CarouselStat = styled.div`
 
 const NetworkOverviewStatsCarousel = ({
   protocolFees,
+  protocolFeesChange,
   tradeCount,
+  tradeCountChange,
   traderCount,
+  traderCountChange,
   tradeVolume,
+  tradeVolumeChange,
 }) => (
   <Slider
     arrows={false}
@@ -40,25 +44,49 @@ const NetworkOverviewStatsCarousel = ({
     slidesToScroll={3}
     slidesToShow={3}
   >
-    <CarouselStat as={TradeVolumeWidget} volume={tradeVolume} />
-    <CarouselStat as={TradeCountWidget} tradeCount={tradeCount} />
-    <CarouselStat as={ActiveTradersWidget} traderCount={traderCount} />
-    <CarouselStat accumulatedFees={protocolFees} as={ProtocolFeesWidget} />
+    <CarouselStat
+      as={TradeVolumeWidget}
+      change={tradeVolumeChange}
+      volume={tradeVolume}
+    />
+    <CarouselStat
+      as={TradeCountWidget}
+      change={tradeCountChange}
+      tradeCount={tradeCount}
+    />
+    <CarouselStat
+      as={ActiveTradersWidget}
+      change={traderCountChange}
+      traderCount={traderCount}
+    />
+    <CarouselStat
+      accumulatedFees={protocolFees}
+      as={ProtocolFeesWidget}
+      change={protocolFeesChange}
+    />
   </Slider>
 );
 
 NetworkOverviewStatsCarousel.propTypes = {
   protocolFees: PropTypes.number,
+  protocolFeesChange: PropTypes.number,
   tradeCount: PropTypes.number,
+  tradeCountChange: PropTypes.number,
   tradeVolume: PropTypes.number,
+  tradeVolumeChange: PropTypes.number,
   traderCount: PropTypes.number,
+  traderCountChange: PropTypes.number,
 };
 
 NetworkOverviewStatsCarousel.defaultProps = {
   protocolFees: undefined,
+  protocolFeesChange: undefined,
   tradeCount: undefined,
+  tradeCountChange: undefined,
   tradeVolume: undefined,
+  tradeVolumeChange: undefined,
   traderCount: undefined,
+  traderCountChange: undefined,
 };
 
 export default NetworkOverviewStatsCarousel;

--- a/src/features/network-overview/components/network-overview-stats.js
+++ b/src/features/network-overview/components/network-overview-stats.js
@@ -19,15 +19,20 @@ const NetworkOverviewStats = ({ period }) => {
   const breakpoint = useCurrentBreakpoint();
 
   const tradeCount = _.get(networkStats, 'tradeCount');
+  const tradeCountChange = _.get(networkStats, 'tradeCountChange');
   const traderCount = _.get(traderStats, 'traderCount');
+  const traderCountChange = _.get(traderStats, 'traderCountChange');
   const tradeVolume = _.get(networkStats, 'tradeVolume');
+  const tradeVolumeChange = _.get(networkStats, 'tradeVolumeChange');
   const protocolFees = _.get(networkStats, 'protocolFees.USD');
+  const protocolFeesChange = _.get(networkStats, 'protocolFeesChange');
 
   if (breakpoint.greaterThan('md')) {
     return (
       <CardGridRow minHeight="80px">
         <CardGridCol lg={3} md={6}>
           <TradeVolumeWidget
+            change={tradeVolumeChange}
             period={period}
             showPeriod={false}
             volume={tradeVolume}
@@ -35,6 +40,7 @@ const NetworkOverviewStats = ({ period }) => {
         </CardGridCol>
         <CardGridCol lg={3} md={6}>
           <TradeCountWidget
+            change={tradeCountChange}
             period={period}
             showPeriod={false}
             tradeCount={tradeCount}
@@ -42,6 +48,7 @@ const NetworkOverviewStats = ({ period }) => {
         </CardGridCol>
         <CardGridCol lg={3} md={6}>
           <ActiveTradersWidget
+            change={traderCountChange}
             period={period}
             showPeriod={false}
             traderCount={traderCount}
@@ -50,6 +57,7 @@ const NetworkOverviewStats = ({ period }) => {
         <CardGridCol lg={3} md={6}>
           <ProtocolFeesWidget
             accumulatedFees={protocolFees}
+            change={protocolFeesChange}
             period={period}
             showPeriod={false}
           />

--- a/src/features/network-overview/components/network-overview-stats.js
+++ b/src/features/network-overview/components/network-overview-stats.js
@@ -69,9 +69,13 @@ const NetworkOverviewStats = ({ period }) => {
   return (
     <NetworkOverviewStatsCarousel
       protocolFees={protocolFees}
+      protocolFeesChange={protocolFeesChange}
       tradeCount={tradeCount}
+      tradeCountChange={tradeCountChange}
       traderCount={traderCount}
+      traderCountChange={traderCountChange}
       tradeVolume={tradeVolume}
+      tradeVolumeChange={tradeVolumeChange}
     />
   );
 };

--- a/src/features/stats/components/protocol-fees-widget.js
+++ b/src/features/stats/components/protocol-fees-widget.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import LoadingIndicator from '../../../components/loading-indicator';
 import LocalisedAmount from '../../currencies/components/localised-amount';
-import PriceChange from '../../../components/price-change';
+import PercentageChange from '../../../components/percentage-change';
 import sharedPropTypes from '../../../prop-types';
 import StatWidget from '../../../components/stat-widget';
 
@@ -39,7 +39,7 @@ const ProtocolFeesWidget = ({
           loadingIndicator={loadingIndicator}
           summarize
         />
-        {change !== undefined && <PriceChange>{change}</PriceChange>}
+        {change !== undefined && <PercentageChange>{change}</PercentageChange>}
       </span>
     ) : (
       loadingIndicator

--- a/src/features/stats/components/protocol-fees-widget.js
+++ b/src/features/stats/components/protocol-fees-widget.js
@@ -4,6 +4,7 @@ import React from 'react';
 
 import LoadingIndicator from '../../../components/loading-indicator';
 import LocalisedAmount from '../../currencies/components/localised-amount';
+import PriceChange from '../../../components/price-change';
 import sharedPropTypes from '../../../prop-types';
 import StatWidget from '../../../components/stat-widget';
 
@@ -19,6 +20,7 @@ const createTooltip = (period) => {
 
 const ProtocolFeesWidget = ({
   accumulatedFees,
+  change,
   className,
   period,
   showPeriod,
@@ -31,11 +33,14 @@ const ProtocolFeesWidget = ({
     tooltip={createTooltip(period)}
   >
     {_.isNumber(accumulatedFees) ? (
-      <LocalisedAmount
-        amount={accumulatedFees}
-        loadingIndicator={loadingIndicator}
-        summarize
-      />
+      <span css="align-items: baseline; display: flex;">
+        <LocalisedAmount
+          amount={accumulatedFees}
+          loadingIndicator={loadingIndicator}
+          summarize
+        />
+        {change !== undefined && <PriceChange>{change}</PriceChange>}
+      </span>
     ) : (
       loadingIndicator
     )}
@@ -44,6 +49,7 @@ const ProtocolFeesWidget = ({
 
 ProtocolFeesWidget.propTypes = {
   accumulatedFees: PropTypes.number,
+  change: PropTypes.number,
   className: PropTypes.string,
   period: sharedPropTypes.timePeriod,
   showPeriod: PropTypes.bool,
@@ -51,6 +57,7 @@ ProtocolFeesWidget.propTypes = {
 
 ProtocolFeesWidget.defaultProps = {
   accumulatedFees: undefined,
+  change: undefined,
   className: undefined,
   period: undefined,
   showPeriod: undefined,

--- a/src/features/tokens/components/token-list-item.js
+++ b/src/features/tokens/components/token-list-item.js
@@ -8,7 +8,7 @@ import formatTokenSymbol from '../util/format-token-symbol';
 import LocalisedAmount from '../../currencies/components/localised-amount';
 import MiniTokenMetrics from '../../metrics/components/mini-token-metrics';
 import Number from '../../../components/number';
-import PriceChange from '../../../components/price-change';
+import PercentageChange from '../../../components/percentage-change';
 import Rank from '../../../components/rank';
 import TokenImage from './token-image';
 import TokenLink from './token-link';
@@ -59,7 +59,7 @@ const TokenListItem = ({ position, statsPeriod, token }) => (
             {token.price.change === null ? null : (
               <>
                 <br />
-                <PriceChange>{token.price.change}</PriceChange>
+                <PercentageChange>{token.price.change}</PercentageChange>
               </>
             )}
           </span>

--- a/src/features/tokens/components/token-page-title.js
+++ b/src/features/tokens/components/token-page-title.js
@@ -7,7 +7,7 @@ import { COLORS } from '../../../styles/constants';
 import { TIME_PERIOD } from '../../../constants';
 import Hidden from '../../../components/hidden';
 import LocalisedAmount from '../../currencies/components/localised-amount';
-import PriceChange from '../../../components/price-change';
+import PercentageChange from '../../../components/percentage-change';
 import SubTitle from '../../../components/sub-title';
 import TokenImage from './token-image';
 import TokenPriceTooltip from './token-price-tooltip';
@@ -62,9 +62,9 @@ const TokenPageTitle = ({ statsPeriod, token }) => (
             {_.isFinite(token.price.change) && (
               <>
                 {' '}
-                <PriceChange css="display: flex; align-items: center;">
+                <PercentageChange css="display: flex; align-items: center;">
                   {token.price.change}
-                </PriceChange>
+                </PercentageChange>
               </>
             )}
           </PriceWrapper>

--- a/src/features/tokens/components/token-price-widget.js
+++ b/src/features/tokens/components/token-price-widget.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import LocalisedAmount from '../../currencies/components/localised-amount';
-import PriceChange from '../../../components/price-change';
+import PercentageChange from '../../../components/percentage-change';
 import StatWidget from '../../../components/stat-widget';
 
 const TokenPriceWidget = ({ className, price }) => (
@@ -15,7 +15,9 @@ const TokenPriceWidget = ({ className, price }) => (
     {_.isFinite(price.close) ? (
       <span>
         <LocalisedAmount amount={price.close} />
-        {_.isFinite(price.change) && <PriceChange>{price.change}</PriceChange>}
+        {_.isFinite(price.change) && (
+          <PercentageChange>{price.change}</PercentageChange>
+        )}
       </span>
     ) : (
       'Not Available'

--- a/src/features/traders/components/active-traders-widget.js
+++ b/src/features/traders/components/active-traders-widget.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import LoadingIndicator from '../../../components/loading-indicator';
 import Number from '../../../components/number';
-import PriceChange from '../../../components/price-change';
+import PercentageChange from '../../../components/percentage-change';
 import sharedPropTypes from '../../../prop-types';
 import StatWidget from '../../../components/stat-widget';
 
@@ -33,7 +33,7 @@ const ActiveTradersWidget = ({
     {_.isNumber(traderCount) ? (
       <span css="align-items: baseline; display: flex;">
         <Number summarize>{traderCount}</Number>
-        {change !== undefined && <PriceChange>{change}</PriceChange>}
+        {change !== undefined && <PercentageChange>{change}</PercentageChange>}
       </span>
     ) : (
       loadingIndicator

--- a/src/features/traders/components/active-traders-widget.js
+++ b/src/features/traders/components/active-traders-widget.js
@@ -4,6 +4,7 @@ import React from 'react';
 
 import LoadingIndicator from '../../../components/loading-indicator';
 import Number from '../../../components/number';
+import PriceChange from '../../../components/price-change';
 import sharedPropTypes from '../../../prop-types';
 import StatWidget from '../../../components/stat-widget';
 
@@ -17,7 +18,12 @@ const createTooltip = (period) => {
   return `Number of unique trader addresses which were active in the last ${period}.`;
 };
 
-const ActiveTradersWidget = ({ period, traderCount, ...otherProps }) => (
+const ActiveTradersWidget = ({
+  change,
+  period,
+  traderCount,
+  ...otherProps
+}) => (
   <StatWidget
     period={period}
     title="Active Traders"
@@ -25,7 +31,10 @@ const ActiveTradersWidget = ({ period, traderCount, ...otherProps }) => (
     {...otherProps}
   >
     {_.isNumber(traderCount) ? (
-      <Number summarize>{traderCount}</Number>
+      <span css="align-items: baseline; display: flex;">
+        <Number summarize>{traderCount}</Number>
+        {change !== undefined && <PriceChange>{change}</PriceChange>}
+      </span>
     ) : (
       loadingIndicator
     )}
@@ -33,12 +42,14 @@ const ActiveTradersWidget = ({ period, traderCount, ...otherProps }) => (
 );
 
 ActiveTradersWidget.propTypes = {
+  change: PropTypes.number,
   className: PropTypes.string,
   period: sharedPropTypes.timePeriod,
   traderCount: PropTypes.number,
 };
 
 ActiveTradersWidget.defaultProps = {
+  change: undefined,
   className: undefined,
   period: undefined,
   traderCount: undefined,


### PR DESCRIPTION
This PR adds percentage change indicators to a bunch of stat widgets across the site.

<img width="1177" alt="Screenshot 2020-05-16 at 11 26 28" src="https://user-images.githubusercontent.com/34132/82124948-32080200-9768-11ea-9ce5-431783d5aefb.png">
