### PR TITLE
Fix sidebar horizontal scroll

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src/components/__snapshots__/app-layout.test.js.snap
+++ b/src/components/__snapshots__/app-layout.test.js.snap
@@ -5,7 +5,7 @@ exports[`app layout component should render with children 1`] = `
   class="app-layout__AppContainer-nr5sez-0 iAFouo"
 >
   <div
-    class="sidebar___StyledDiv-sc-1ginpey-1 iddpQE"
+    class="sidebar___StyledDiv-sc-1ginpey-1 cqKTGM"
   >
     <a
       class="link__StyledLink-sc-1m1n17q-0 diqghp sidebar___StyledLink-sc-1ginpey-2 kJBkBW"

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -20,7 +20,8 @@ const Sidebar = () => (
       background: ${COLORS.PRIMARY.SCAMPI_1000};
       height: 100vh;
       flex-shrink: 0;
-      overflow-y: scroll;
+      overflow-x: hidden;
+      overflow-y: auto;
       display: flex;
       flex-direction: column;
     `}

--- a/src/features/advertising/components/side-banner-view.js
+++ b/src/features/advertising/components/side-banner-view.js
@@ -27,7 +27,7 @@ const Wrapper = styled.div`
   color: white;
   border-radius: 4px;
   padding: 12px;
-  width: 226px;
+  min-width: 200px;
   text-align: center;
   margin: 0 12px 12px 12px;
 `;


### PR DESCRIPTION
Fixes #978 

Also I added `.gitattributes` as in Prettier's docs https://prettier.io/docs/en/options.html#end-of-line . Without it git will automatically convert to CRLF on Windows and prettier will complain about it because since version 2, Prettier has default `endOfLine = lf`

Please verify that on macOS everything works as expected