### PR TITLE
Remove survey header from page header

### DIFF
--- a/src/features/header/components/header.js
+++ b/src/features/header/components/header.js
@@ -7,7 +7,6 @@ import { MenuIcon, SearchIcon } from '../../../components/icons';
 import { useCurrentBreakpoint } from '../../../responsive-utils';
 import HeaderActions from './header-actions';
 import MobileMenu from './mobile-menu';
-import SurveyBanner from '../../../components/survey-banner';
 import SearchBox from '../../search/components/search-box';
 import SettingsDialogProvider from '../../preferences/components/settings-dialog-provider';
 import { media } from '../../../styles/util';
@@ -92,7 +91,6 @@ const Header = () => {
           )}
         </div>
       </StyledHeader>
-      <SurveyBanner />
     </SettingsDialogProvider>
   );
 };

--- a/src/features/header/components/mobile-header.js
+++ b/src/features/header/components/mobile-header.js
@@ -10,7 +10,6 @@ import logoImage from '../../../assets/images/logo-grayscale.svg';
 import MobileMenu from './mobile-menu';
 import MobileSearch from './mobile-search';
 import SettingsDialogProvider from '../../preferences/components/settings-dialog-provider';
-import SurveyBanner from '../../../components/survey-banner';
 import { media } from '../../../styles/util';
 
 const LogoImage = styled.img`
@@ -99,7 +98,6 @@ const MobileHeader = () => {
           )}
         </Actions>
       </StyledHeader>
-      <SurveyBanner isMobile />
 
       {searchVisible && (
         <MobileSearch


### PR DESCRIPTION
Heyo, 

this PR removes the survey banner as it will not be used anymore. 
I chose to only remove the usages of `SurveyBanner` but not remove the component itself in case 
we want to bring it back in the future. 

Before:
<img width="1430" alt="Screenshot 2022-03-09 at 11 04 15" src="https://user-images.githubusercontent.com/24787761/157419821-0712ae78-2e74-41b7-bfae-b57986750bd6.png">

After:
<img width="1431" alt="Screenshot 2022-03-09 at 11 04 24" src="https://user-images.githubusercontent.com/24787761/157419877-a4f63107-56ab-4da5-813f-7af79a1de066.png">

